### PR TITLE
[3.0] Reorder KhronosVendor suffixes to be last

### DIFF
--- a/generator.json
+++ b/generator.json
@@ -186,6 +186,9 @@
           "FunctionPointerDelegateType": {
             "Order": 1
           },
+          "KhronosVendor": {
+            "Order": -1
+          },
           "KhronosFunctionDataType": {
             "IsDiscriminator": true
           },
@@ -319,6 +322,9 @@
           "FunctionPointerDelegateType": {
             "Order": 1
           },
+          "KhronosVendor": {
+            "Order": -1
+          },
           "KhronosFunctionDataType": {
             "IsDiscriminator": true
           },
@@ -430,6 +436,9 @@
           },
           "FunctionPointerDelegateType": {
             "Order": 1
+          },
+          "KhronosVendor": {
+            "Order": -1
           },
           "KhronosImpliedVendor": {
             "Remove": true

--- a/sources/Core/Core/Annotations/NameAffixAttribute.cs
+++ b/sources/Core/Core/Annotations/NameAffixAttribute.cs
@@ -7,13 +7,13 @@ namespace Silk.NET.Core;
 /// </summary>
 [AttributeUsage(
     AttributeTargets.Class
-    | AttributeTargets.Delegate
-    | AttributeTargets.Enum
-    | AttributeTargets.Field
-    | AttributeTargets.Method
-    | AttributeTargets.Parameter
-    | AttributeTargets.Property
-    | AttributeTargets.Struct,
+        | AttributeTargets.Delegate
+        | AttributeTargets.Enum
+        | AttributeTargets.Field
+        | AttributeTargets.Method
+        | AttributeTargets.Parameter
+        | AttributeTargets.Property
+        | AttributeTargets.Struct,
     AllowMultiple = true,
     Inherited = true
 )]

--- a/sources/Core/Core/Annotations/NativeNameAttribute.cs
+++ b/sources/Core/Core/Annotations/NativeNameAttribute.cs
@@ -8,13 +8,13 @@ namespace Silk.NET.Core;
 /// </summary>
 [AttributeUsage(
     AttributeTargets.Class
-    | AttributeTargets.Delegate
-    | AttributeTargets.Enum
-    | AttributeTargets.Field
-    | AttributeTargets.Method
-    | AttributeTargets.Parameter
-    | AttributeTargets.Property
-    | AttributeTargets.Struct,
+        | AttributeTargets.Delegate
+        | AttributeTargets.Enum
+        | AttributeTargets.Field
+        | AttributeTargets.Method
+        | AttributeTargets.Parameter
+        | AttributeTargets.Property
+        | AttributeTargets.Struct,
     AllowMultiple = false,
     Inherited = true
 )]

--- a/sources/OpenAL/OpenAL/al/AL.gen.cs
+++ b/sources/OpenAL/OpenAL/al/AL.gen.cs
@@ -6297,12 +6297,12 @@ public unsafe partial class AL : IAL, IAL.Static
         [SupportedApiProfile("al", ["AL_SOFT_buffer_samples"])]
         [NativeFunction("openal", EntryPoint = "alIsBufferFormatSupportedSOFT")]
         public static MaybeBool<sbyte> IsBufferFormatSupportedSOFT(int format) =>
-            (MaybeBool<sbyte>)(sbyte)IsBufferFormatSupportedSOFTRaw(format);
+            (MaybeBool<sbyte>)(sbyte)IsBufferFormatSupportedRawSOFT(format);
 
         [NativeName("alIsBufferFormatSupportedSOFT")]
         [DllImport("openal", ExactSpelling = true, EntryPoint = "alIsBufferFormatSupportedSOFT")]
         [SupportedApiProfile("al", ["AL_SOFT_buffer_samples"])]
-        public static extern sbyte IsBufferFormatSupportedSOFTRaw(int format);
+        public static extern sbyte IsBufferFormatSupportedRawSOFT(int format);
 
         [NativeName("alIsBuffer")]
         [DllImport("openal", ExactSpelling = true, EntryPoint = "alIsBuffer")]
@@ -14213,8 +14213,8 @@ public unsafe partial class AL : IAL, IAL.Static
         [MethodImpl(
             MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization
         )]
-        public sbyte IsBufferFormatSupportedSOFTRaw(int format) =>
-            T.IsBufferFormatSupportedSOFTRaw(format);
+        public sbyte IsBufferFormatSupportedRawSOFT(int format) =>
+            T.IsBufferFormatSupportedRawSOFT(format);
 
         [NativeName("alIsBuffer")]
         [SupportedApiProfile("al", ["AL_VERSION_1_0", "AL_VERSION_1_1"], MinVersion = "1.0")]
@@ -23624,8 +23624,8 @@ public unsafe partial class AL : IAL, IAL.Static
         [MethodImpl(
             MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization
         )]
-        public static sbyte IsBufferFormatSupportedSOFTRaw(int format) =>
-            Underlying.Value!.IsBufferFormatSupportedSOFTRaw(format);
+        public static sbyte IsBufferFormatSupportedRawSOFT(int format) =>
+            Underlying.Value!.IsBufferFormatSupportedRawSOFT(format);
 
         [NativeName("alIsBuffer")]
         [SupportedApiProfile("al", ["AL_VERSION_1_0", "AL_VERSION_1_1"], MinVersion = "1.0")]
@@ -38500,7 +38500,7 @@ public unsafe partial class AL : IAL, IAL.Static
     [NativeFunction("openal", EntryPoint = "alIsBufferFormatSupportedSOFT")]
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     MaybeBool<sbyte> IAL.IsBufferFormatSupportedSOFT(int format) =>
-        (MaybeBool<sbyte>)(sbyte)((IAL)this).IsBufferFormatSupportedSOFTRaw(format);
+        (MaybeBool<sbyte>)(sbyte)((IAL)this).IsBufferFormatSupportedRawSOFT(format);
 
     [NativeName("alIsBufferFormatSupportedSOFT")]
     [SupportedApiProfile("al", ["AL_SOFT_buffer_samples"])]
@@ -38513,7 +38513,7 @@ public unsafe partial class AL : IAL, IAL.Static
     [SupportedApiProfile("al", ["AL_SOFT_buffer_samples"])]
     [NativeFunction("openal", EntryPoint = "alIsBufferFormatSupportedSOFT")]
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    sbyte IAL.IsBufferFormatSupportedSOFTRaw(int format) =>
+    sbyte IAL.IsBufferFormatSupportedRawSOFT(int format) =>
         (
             (delegate* unmanaged<int, sbyte>)(
                 _slots[208] is not null and var loadedFnPtr
@@ -38529,8 +38529,8 @@ public unsafe partial class AL : IAL, IAL.Static
     [SupportedApiProfile("al", ["AL_SOFT_buffer_samples"])]
     [NativeFunction("openal", EntryPoint = "alIsBufferFormatSupportedSOFT")]
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    public static sbyte IsBufferFormatSupportedSOFTRaw(int format) =>
-        ThisThread.IsBufferFormatSupportedSOFTRaw(format);
+    public static sbyte IsBufferFormatSupportedRawSOFT(int format) =>
+        ThisThread.IsBufferFormatSupportedRawSOFT(format);
 
     [NativeName("alIsBuffer")]
     [SupportedApiProfile("al", ["AL_VERSION_1_0", "AL_VERSION_1_1"], MinVersion = "1.0")]

--- a/sources/OpenAL/OpenAL/al/IAL.gen.cs
+++ b/sources/OpenAL/OpenAL/al/IAL.gen.cs
@@ -4458,7 +4458,7 @@ public unsafe partial interface IAL
         [NativeName("alIsBufferFormatSupportedSOFT")]
         [SupportedApiProfile("al", ["AL_SOFT_buffer_samples"])]
         [NativeFunction("openal", EntryPoint = "alIsBufferFormatSupportedSOFT")]
-        static abstract sbyte IsBufferFormatSupportedSOFTRaw(int format);
+        static abstract sbyte IsBufferFormatSupportedRawSOFT(int format);
 
         [NativeName("alIsBuffer")]
         [SupportedApiProfile("al", ["AL_VERSION_1_0", "AL_VERSION_1_1"], MinVersion = "1.0")]
@@ -10031,7 +10031,7 @@ public unsafe partial interface IAL
     [NativeName("alIsBufferFormatSupportedSOFT")]
     [SupportedApiProfile("al", ["AL_SOFT_buffer_samples"])]
     [NativeFunction("openal", EntryPoint = "alIsBufferFormatSupportedSOFT")]
-    sbyte IsBufferFormatSupportedSOFTRaw(int format);
+    sbyte IsBufferFormatSupportedRawSOFT(int format);
 
     [NativeName("alIsBuffer")]
     [SupportedApiProfile("al", ["AL_VERSION_1_0", "AL_VERSION_1_1"], MinVersion = "1.0")]

--- a/sources/SilkTouch/SilkTouch/Mods/AddIncludes.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/AddIncludes.cs
@@ -64,8 +64,13 @@ public class AddIncludes(
             var rsp = rsps[i];
             var cmdLineArgs = rsp.ClangCommandLineArgs.ToList();
 
-            cmdLineArgs.InsertRange(0, cfg.PriorityIncludes?.Select(x => $"--include-directory={x}") ?? []);
-            cmdLineArgs.AddRange(cfg.AdditionalIncludes?.Select(x => $"--include-directory={x}") ?? []);
+            cmdLineArgs.InsertRange(
+                0,
+                cfg.PriorityIncludes?.Select(x => $"--include-directory={x}") ?? []
+            );
+            cmdLineArgs.AddRange(
+                cfg.AdditionalIncludes?.Select(x => $"--include-directory={x}") ?? []
+            );
 
             if (!cfg.SuppressStdIncludes)
             {

--- a/sources/SilkTouch/SilkTouch/Mods/AddVTables.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/AddVTables.cs
@@ -999,8 +999,7 @@ public class AddVTables(IOptionsSnapshot<AddVTables.Configuration> config) : IMo
                         && x.ChildTokens()
                             .FirstOrDefault(y => y.IsKind(SyntaxKind.IdentifierToken))
                             .ToString() == tok.ToString()
-                    )
-                    ?? false
+                    ) ?? false
                 )
             )
             {

--- a/sources/SilkTouch/SilkTouch/Mods/AddVTables.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/AddVTables.cs
@@ -777,9 +777,13 @@ public class AddVTables(IOptionsSnapshot<AddVTables.Configuration> config) : IMo
                                 x.WithAttributes(
                                     SeparatedList(
                                         x.Attributes.Where(y =>
-                                            !y.IsAttribute("System.Runtime.InteropServices.DllImport")
+                                            !y.IsAttribute(
+                                                "System.Runtime.InteropServices.DllImport"
+                                            )
                                             && !y.IsAttribute("Silk.NET.Core.NativeFunction")
-                                            && !y.IsAttribute("System.Runtime.CompilerServices.MethodImpl")
+                                            && !y.IsAttribute(
+                                                "System.Runtime.CompilerServices.MethodImpl"
+                                            )
                                         )
                                     )
                                 )
@@ -995,7 +999,8 @@ public class AddVTables(IOptionsSnapshot<AddVTables.Configuration> config) : IMo
                         && x.ChildTokens()
                             .FirstOrDefault(y => y.IsKind(SyntaxKind.IdentifierToken))
                             .ToString() == tok.ToString()
-                    ) ?? false
+                    )
+                    ?? false
                 )
             )
             {

--- a/sources/SilkTouch/SilkTouch/Mods/Bakery/DefaultBakeStrategy.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Bakery/DefaultBakeStrategy.cs
@@ -80,8 +80,7 @@ public class DefaultBakeStrategy(ILogger<DefaultBakeStrategy> logger) : IBakeStr
                             ty.BaseList.Types.Concat(
                                     ((BaseTypeDeclarationSyntax)existing.Value.Syntax)
                                         .BaseList
-                                        ?.Types
-                                        ?? []
+                                        ?.Types ?? []
                                 )
                                 .DistinctBy(x => x.ToString())
                         )
@@ -213,6 +212,7 @@ public class DefaultBakeStrategy(ILogger<DefaultBakeStrategy> logger) : IBakeStr
         // Check that constants and enums have the same value
         if (
             (existing.Value.Syntax, node) is
+
             (EnumMemberDeclarationSyntax lEnum, EnumMemberDeclarationSyntax rEnum)
         )
         {
@@ -228,6 +228,7 @@ public class DefaultBakeStrategy(ILogger<DefaultBakeStrategy> logger) : IBakeStr
         }
         else if (
             (existing.Value.Syntax, node) is
+
             (FieldDeclarationSyntax lConst, FieldDeclarationSyntax rConst)
         )
         {

--- a/sources/SilkTouch/SilkTouch/Mods/Bakery/DefaultBakeStrategy.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Bakery/DefaultBakeStrategy.cs
@@ -80,7 +80,8 @@ public class DefaultBakeStrategy(ILogger<DefaultBakeStrategy> logger) : IBakeStr
                             ty.BaseList.Types.Concat(
                                     ((BaseTypeDeclarationSyntax)existing.Value.Syntax)
                                         .BaseList
-                                        ?.Types ?? []
+                                        ?.Types
+                                        ?? []
                                 )
                                 .DistinctBy(x => x.ToString())
                         )
@@ -197,7 +198,9 @@ public class DefaultBakeStrategy(ILogger<DefaultBakeStrategy> logger) : IBakeStr
                     node.AttributeLists.Select(x =>
                             x.WithAttributes(
                                 SeparatedList(
-                                    x.Attributes.Where(y => y.IsAttribute("Silk.NET.Core.SupportedApiAttribute"))
+                                    x.Attributes.Where(y =>
+                                        y.IsAttribute("Silk.NET.Core.SupportedApiAttribute")
+                                    )
                                 )
                             )
                         )
@@ -210,7 +213,6 @@ public class DefaultBakeStrategy(ILogger<DefaultBakeStrategy> logger) : IBakeStr
         // Check that constants and enums have the same value
         if (
             (existing.Value.Syntax, node) is
-
             (EnumMemberDeclarationSyntax lEnum, EnumMemberDeclarationSyntax rEnum)
         )
         {
@@ -226,7 +228,6 @@ public class DefaultBakeStrategy(ILogger<DefaultBakeStrategy> logger) : IBakeStr
         }
         else if (
             (existing.Value.Syntax, node) is
-
             (FieldDeclarationSyntax lConst, FieldDeclarationSyntax rConst)
         )
         {

--- a/sources/SilkTouch/SilkTouch/Mods/Common/AttributeUtils.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Common/AttributeUtils.cs
@@ -29,9 +29,9 @@ public static class AttributeUtils
         var sep = node.Name.ToString().Split("::").Last();
         var name = fullNameWithoutSuffix.Split('.').Last();
         return sep == name
-               || sep == $"{name}Attribute"
-               || sep.EndsWith(fullNameWithoutSuffix)
-               || sep.EndsWith($"{fullNameWithoutSuffix}Attribute");
+            || sep == $"{name}Attribute"
+            || sep.EndsWith(fullNameWithoutSuffix)
+            || sep.EndsWith($"{fullNameWithoutSuffix}Attribute");
     }
 
     /// <summary>
@@ -41,8 +41,13 @@ public static class AttributeUtils
     /// <param name="fullNameWithoutSuffix">
     /// The fully-qualified attribute name including the namespace but without the <c>Attribute</c> suffix.
     /// </param>
-    public static bool ContainsAttribute(this IEnumerable<AttributeListSyntax> attributeLists, string fullNameWithoutSuffix) =>
-        attributeLists.Any(list => list.Attributes.Any(attribute => attribute.IsAttribute(fullNameWithoutSuffix)));
+    public static bool ContainsAttribute(
+        this IEnumerable<AttributeListSyntax> attributeLists,
+        string fullNameWithoutSuffix
+    ) =>
+        attributeLists.Any(list =>
+            list.Attributes.Any(attribute => attribute.IsAttribute(fullNameWithoutSuffix))
+        );
 
     /// <summary>
     /// Modifies the <see cref="DllImportAttribute"/>s the method may have to make them resistant to method identifier
@@ -63,7 +68,8 @@ public static class AttributeUtils
                                 && (
                                     y.ArgumentList?.Arguments.All(z =>
                                         z.NameEquals?.Name.ToString() != "EntryPoint"
-                                    ) ?? true
+                                    )
+                                    ?? true
                                 )
                                     ? y.AddArgumentListArguments(
                                         AttributeArgument(
@@ -209,8 +215,12 @@ public static class AttributeUtils
     /// Use false if not (outside or appended to end).
     /// True means that the attribute is added to the start of the attribute list, meaning that the affix is re-appended earlier.
     /// </param>
-    public static SyntaxList<AttributeListSyntax> AddNamePrefix(this IEnumerable<AttributeListSyntax> attributeLists, string category, string prefix, bool addToInner = false)
-        => attributeLists.AddNamePrefixOrSuffix("Prefix", category, prefix, addToInner);
+    public static SyntaxList<AttributeListSyntax> AddNamePrefix(
+        this IEnumerable<AttributeListSyntax> attributeLists,
+        string category,
+        string prefix,
+        bool addToInner = false
+    ) => attributeLists.AddNamePrefixOrSuffix("Prefix", category, prefix, addToInner);
 
     /// <summary>
     /// Adds a name suffix attribute to the given attribute list.
@@ -223,23 +233,38 @@ public static class AttributeUtils
     /// Use false if not (outside or appended to end).
     /// True means that the attribute is added to the start of the attribute list, meaning that the affix is re-appended earlier.
     /// </param>
-    public static SyntaxList<AttributeListSyntax> AddNameSuffix(this IEnumerable<AttributeListSyntax> attributeLists, string category, string suffix, bool addToInner = false)
-        => attributeLists.AddNamePrefixOrSuffix("Suffix", category, suffix, addToInner);
+    public static SyntaxList<AttributeListSyntax> AddNameSuffix(
+        this IEnumerable<AttributeListSyntax> attributeLists,
+        string category,
+        string suffix,
+        bool addToInner = false
+    ) => attributeLists.AddNamePrefixOrSuffix("Suffix", category, suffix, addToInner);
 
-    private static SyntaxList<AttributeListSyntax> AddNamePrefixOrSuffix(this IEnumerable<AttributeListSyntax> attributeLists, string type, string category, string affix, bool addToInner = false)
+    private static SyntaxList<AttributeListSyntax> AddNamePrefixOrSuffix(
+        this IEnumerable<AttributeListSyntax> attributeLists,
+        string type,
+        string category,
+        string affix,
+        bool addToInner = false
+    )
     {
-        var typeArgument = AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal($"\"{type}\"", type)));
-        var categoryArgument = AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal($"\"{category}\"", category)));
-        var affixArgument = AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal($"\"{affix}\"", affix)));
+        var typeArgument = AttributeArgument(
+            LiteralExpression(SyntaxKind.StringLiteralExpression, Literal($"\"{type}\"", type))
+        );
+        var categoryArgument = AttributeArgument(
+            LiteralExpression(
+                SyntaxKind.StringLiteralExpression,
+                Literal($"\"{category}\"", category)
+            )
+        );
+        var affixArgument = AttributeArgument(
+            LiteralExpression(SyntaxKind.StringLiteralExpression, Literal($"\"{affix}\"", affix))
+        );
         var argumentList = AttributeArgumentList([typeArgument, categoryArgument, affixArgument]);
 
-        var attribute = AttributeList([
-            Attribute(IdentifierName("NameAffix"), argumentList),
-        ]);
+        var attribute = AttributeList([Attribute(IdentifierName("NameAffix"), argumentList)]);
 
-        return addToInner
-            ? [attribute, ..attributeLists]
-            : [..attributeLists, attribute];
+        return addToInner ? [attribute, .. attributeLists] : [.. attributeLists, attribute];
     }
 
     /// <summary>
@@ -248,7 +273,10 @@ public static class AttributeUtils
     /// <remarks>
     /// The default usually should be the node's identifier.
     /// </remarks>
-    public static string GetNativeNameOrDefault(this IEnumerable<AttributeListSyntax> attributeLists, SyntaxToken identifier)
+    public static string GetNativeNameOrDefault(
+        this IEnumerable<AttributeListSyntax> attributeLists,
+        SyntaxToken identifier
+    )
     {
         if (TryGetNativeName(attributeLists, out var nativeName))
         {
@@ -264,7 +292,10 @@ public static class AttributeUtils
     /// <remarks>
     /// The default usually should be the node's identifier.
     /// </remarks>
-    public static string GetNativeNameOrDefault(this IEnumerable<AttributeListSyntax> attributeLists, string defaultName)
+    public static string GetNativeNameOrDefault(
+        this IEnumerable<AttributeListSyntax> attributeLists,
+        string defaultName
+    )
     {
         if (TryGetNativeName(attributeLists, out var nativeName))
         {
@@ -277,9 +308,14 @@ public static class AttributeUtils
     /// <summary>
     /// Gets the value of the native name attribute from the given attribute list.
     /// </summary>
-    public static bool TryGetNativeName(this IEnumerable<AttributeListSyntax> attributeLists, [NotNullWhen(true)] out string? nativeName)
+    public static bool TryGetNativeName(
+        this IEnumerable<AttributeListSyntax> attributeLists,
+        [NotNullWhen(true)] out string? nativeName
+    )
     {
-        var nativeNameAttribute = attributeLists.SelectMany(list => list.Attributes).FirstOrDefault(attribute => attribute.IsAttribute("Silk.NET.Core.NativeName"));
+        var nativeNameAttribute = attributeLists
+            .SelectMany(list => list.Attributes)
+            .FirstOrDefault(attribute => attribute.IsAttribute("Silk.NET.Core.NativeName"));
         if (nativeNameAttribute == null)
         {
             nativeName = null;
@@ -295,25 +331,43 @@ public static class AttributeUtils
     /// <summary>
     /// Sets or replaces the native name attribute in the given attribute list.
     /// </summary>
-    public static SyntaxList<AttributeListSyntax> WithNativeName(this IEnumerable<AttributeListSyntax> attributeLists, string nativeName)
+    public static SyntaxList<AttributeListSyntax> WithNativeName(
+        this IEnumerable<AttributeListSyntax> attributeLists,
+        string nativeName
+    )
     {
         var nativeNameAttribute = AttributeList([
             Attribute(
                 IdentifierName("NativeName"),
                 AttributeArgumentList([
-                    AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal($"\"{nativeName}\"", nativeName))),
-                ])),
+                    AttributeArgument(
+                        LiteralExpression(
+                            SyntaxKind.StringLiteralExpression,
+                            Literal($"\"{nativeName}\"", nativeName)
+                        )
+                    ),
+                ])
+            ),
         ]);
 
-        return List(attributeLists.Select(list => {
-                var attributes = list.Attributes;
-                attributes = [..attributes.Where(attribute => !attribute.IsAttribute("Silk.NET.Core.NativeName"))];
+        return List(
+            attributeLists
+                .Select(list =>
+                {
+                    var attributes = list.Attributes;
+                    attributes =
+                    [
+                        .. attributes.Where(attribute =>
+                            !attribute.IsAttribute("Silk.NET.Core.NativeName")
+                        ),
+                    ];
 
-                return attributes.Count == 0 ? null : list.WithAttributes(attributes);
-            })
-            .Where(list => list != null)
-            .Cast<AttributeListSyntax>()
-            .Prepend(nativeNameAttribute));
+                    return attributes.Count == 0 ? null : list.WithAttributes(attributes);
+                })
+                .Where(list => list != null)
+                .Cast<AttributeListSyntax>()
+                .Prepend(nativeNameAttribute)
+        );
     }
 
     /// <summary>
@@ -368,7 +422,7 @@ public static class AttributeUtils
         switch (nativeTypeName)
         {
             // Handle case: "#define NAME VALUE"
-            case {} when nativeTypeName.StartsWith("#define "):
+            case { } when nativeTypeName.StartsWith("#define "):
             {
                 // Trim off the #define
                 var nativeTypeSpan = nativeTypeName["#define ".Length..].Trim();
@@ -404,7 +458,7 @@ public static class AttributeUtils
             }
 
             // Handle cases: "const NAME **", "NAME **"
-            case {}:
+            case { }:
             {
                 // Trim off the const
                 var isConst = false;

--- a/sources/SilkTouch/SilkTouch/Mods/Common/AttributeUtils.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Common/AttributeUtils.cs
@@ -68,8 +68,7 @@ public static class AttributeUtils
                                 && (
                                     y.ArgumentList?.Arguments.All(z =>
                                         z.NameEquals?.Name.ToString() != "EntryPoint"
-                                    )
-                                    ?? true
+                                    ) ?? true
                                 )
                                     ? y.AddArgumentListArguments(
                                         AttributeArgument(
@@ -336,19 +335,23 @@ public static class AttributeUtils
         string nativeName
     )
     {
-        var nativeNameAttribute = AttributeList([
-            Attribute(
-                IdentifierName("NativeName"),
-                AttributeArgumentList([
-                    AttributeArgument(
-                        LiteralExpression(
-                            SyntaxKind.StringLiteralExpression,
-                            Literal($"\"{nativeName}\"", nativeName)
-                        )
-                    ),
-                ])
-            ),
-        ]);
+        var nativeNameAttribute = AttributeList(
+            [
+                Attribute(
+                    IdentifierName("NativeName"),
+                    AttributeArgumentList(
+                        [
+                            AttributeArgument(
+                                LiteralExpression(
+                                    SyntaxKind.StringLiteralExpression,
+                                    Literal($"\"{nativeName}\"", nativeName)
+                                )
+                            ),
+                        ]
+                    )
+                ),
+            ]
+        );
 
         return List(
             attributeLists

--- a/sources/SilkTouch/SilkTouch/Mods/Common/ModCSharpSyntaxRewriter.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Common/ModCSharpSyntaxRewriter.cs
@@ -16,9 +16,8 @@ public abstract class ModCSharpSyntaxRewriter(bool visitIntoStructuredTrivia = f
     : CSharpSyntaxRewriter(visitIntoStructuredTrivia),
         ITransformationContext
 {
-    private ThreadLocal<Dictionary<string, UsingDirectiveSyntax>> _usingsToAdd = new(() =>
-        new Dictionary<string, UsingDirectiveSyntax>()
-    );
+    private ThreadLocal<Dictionary<string, UsingDirectiveSyntax>> _usingsToAdd =
+        new(() => new Dictionary<string, UsingDirectiveSyntax>());
 
     /// <summary>
     /// <c>using</c>s to add to the appropriate place within the syntax tree.

--- a/sources/SilkTouch/SilkTouch/Mods/Common/ModCSharpSyntaxRewriter.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Common/ModCSharpSyntaxRewriter.cs
@@ -16,8 +16,9 @@ public abstract class ModCSharpSyntaxRewriter(bool visitIntoStructuredTrivia = f
     : CSharpSyntaxRewriter(visitIntoStructuredTrivia),
         ITransformationContext
 {
-    private ThreadLocal<Dictionary<string, UsingDirectiveSyntax>> _usingsToAdd =
-        new(() => new Dictionary<string, UsingDirectiveSyntax>());
+    private ThreadLocal<Dictionary<string, UsingDirectiveSyntax>> _usingsToAdd = new(() =>
+        new Dictionary<string, UsingDirectiveSyntax>()
+    );
 
     /// <summary>
     /// <c>using</c>s to add to the appropriate place within the syntax tree.
@@ -37,7 +38,9 @@ public abstract class ModCSharpSyntaxRewriter(bool visitIntoStructuredTrivia = f
             return ret;
         }
 
-        foreach (var use in comp.Usings.Where(use => !use.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword)))
+        foreach (
+            var use in comp.Usings.Where(use => !use.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword))
+        )
         {
             AddUsing(use);
         }
@@ -68,7 +71,9 @@ public abstract class ModCSharpSyntaxRewriter(bool visitIntoStructuredTrivia = f
         FileScopedNamespaceDeclarationSyntax node
     )
     {
-        foreach (var use in node.Usings.Where(use => !use.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword)))
+        foreach (
+            var use in node.Usings.Where(use => !use.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword))
+        )
         {
             AddUsing(use);
         }

--- a/sources/SilkTouch/SilkTouch/Mods/Common/ModUtils.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Common/ModUtils.cs
@@ -104,7 +104,8 @@ public static class ModUtils
     public static string DiscrimStr(SyntaxTokenList? toks, TypeSyntax? type) =>
         toks?.Any(x =>
             x.Kind() is SyntaxKind.RefKeyword or SyntaxKind.InKeyword or SyntaxKind.OutKeyword
-        ) ?? false
+        )
+        ?? false
             ? $"{type}&"
             : type?.ToString() ?? string.Empty;
 
@@ -187,14 +188,20 @@ public static class ModUtils
     /// <summary>
     /// Searches and replaces all occurrences of the <paramref name="oldValue"/> with the <paramref name="newValue"/> in the document name and project *relative* file path.
     /// </summary>
-    public static Document ReplaceNameAndPath(this Document document, string oldValue, string newValue)
+    public static Document ReplaceNameAndPath(
+        this Document document,
+        string oldValue,
+        string newValue
+    )
     {
         document = document.WithName(document.Name.Replace(oldValue, newValue));
 
         var relativePath = document.RelativePath();
         if (relativePath != null)
         {
-            document = document.WithFilePath(FullPath(document.Project, relativePath.Replace(oldValue, newValue)));
+            document = document.WithFilePath(
+                FullPath(document.Project, relativePath.Replace(oldValue, newValue))
+            );
         }
 
         return document;

--- a/sources/SilkTouch/SilkTouch/Mods/Common/ModUtils.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Common/ModUtils.cs
@@ -104,8 +104,7 @@ public static class ModUtils
     public static string DiscrimStr(SyntaxTokenList? toks, TypeSyntax? type) =>
         toks?.Any(x =>
             x.Kind() is SyntaxKind.RefKeyword or SyntaxKind.InKeyword or SyntaxKind.OutKeyword
-        )
-        ?? false
+        ) ?? false
             ? $"{type}&"
             : type?.ToString() ?? string.Empty;
 

--- a/sources/SilkTouch/SilkTouch/Mods/ExtractNestedTyping.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/ExtractNestedTyping.cs
@@ -792,149 +792,156 @@ public partial class ExtractNestedTyping(ILogger<ExtractNestedTyping> logger) : 
             )
             .WithAttributeLists(pfnAttrLists)
             .WithMembers(
-                List<MemberDeclarationSyntax>([
-                    FieldDeclaration(
-                            VariableDeclaration(
-                                PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword))),
-                                SingletonSeparatedList(VariableDeclarator("_pointer"))
-                            )
-                        )
-                        .WithModifiers(
-                            TokenList(
-                                Token(SyntaxKind.PrivateKeyword),
-                                Token(SyntaxKind.ReadOnlyKeyword)
-                            )
-                        ),
-                    PropertyDeclaration(rawPfn, "Handle")
-                        .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
-                        .WithExpressionBody(
-                            ArrowExpressionClause(
-                                CastExpression(rawPfn, IdentifierName("_pointer"))
-                            )
-                        )
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                    ConstructorDeclaration(pfnName)
-                        .WithParameterList(
-                            ParameterList(
-                                SingletonSeparatedList(
-                                    Parameter(Identifier("ptr")).WithType(rawPfn)
+                List<MemberDeclarationSyntax>(
+                    [
+                        FieldDeclaration(
+                                VariableDeclaration(
+                                    PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword))),
+                                    SingletonSeparatedList(VariableDeclarator("_pointer"))
                                 )
                             )
-                        )
-                        .WithExpressionBody(
-                            ArrowExpressionClause(
-                                AssignmentExpression(
-                                    SyntaxKind.SimpleAssignmentExpression,
-                                    IdentifierName("_pointer"),
-                                    IdentifierName("ptr")
+                            .WithModifiers(
+                                TokenList(
+                                    Token(SyntaxKind.PrivateKeyword),
+                                    Token(SyntaxKind.ReadOnlyKeyword)
+                                )
+                            ),
+                        PropertyDeclaration(rawPfn, "Handle")
+                            .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                            .WithExpressionBody(
+                                ArrowExpressionClause(
+                                    CastExpression(rawPfn, IdentifierName("_pointer"))
                                 )
                             )
-                        )
-                        .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                    ConstructorDeclaration(pfnName)
-                        .WithParameterList(
-                            ParameterList(
-                                SingletonSeparatedList(
-                                    Parameter(Identifier("proc"))
-                                        .WithType(IdentifierName(delegateName))
+                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                        ConstructorDeclaration(pfnName)
+                            .WithParameterList(
+                                ParameterList(
+                                    SingletonSeparatedList(
+                                        Parameter(Identifier("ptr")).WithType(rawPfn)
+                                    )
                                 )
                             )
-                        )
-                        .WithExpressionBody(
-                            ArrowExpressionClause(
-                                AssignmentExpression(
-                                    SyntaxKind.SimpleAssignmentExpression,
-                                    IdentifierName("_pointer"),
-                                    InvocationExpression(
-                                        MemberAccessExpression(
-                                            SyntaxKind.SimpleMemberAccessExpression,
-                                            IdentifierName("SilkMarshal"),
-                                            IdentifierName("DelegateToPtr")
-                                        ),
-                                        ArgumentList(
-                                            SingletonSeparatedList(Argument(IdentifierName("proc")))
+                            .WithExpressionBody(
+                                ArrowExpressionClause(
+                                    AssignmentExpression(
+                                        SyntaxKind.SimpleAssignmentExpression,
+                                        IdentifierName("_pointer"),
+                                        IdentifierName("ptr")
+                                    )
+                                )
+                            )
+                            .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                        ConstructorDeclaration(pfnName)
+                            .WithParameterList(
+                                ParameterList(
+                                    SingletonSeparatedList(
+                                        Parameter(Identifier("proc"))
+                                            .WithType(IdentifierName(delegateName))
+                                    )
+                                )
+                            )
+                            .WithExpressionBody(
+                                ArrowExpressionClause(
+                                    AssignmentExpression(
+                                        SyntaxKind.SimpleAssignmentExpression,
+                                        IdentifierName("_pointer"),
+                                        InvocationExpression(
+                                            MemberAccessExpression(
+                                                SyntaxKind.SimpleMemberAccessExpression,
+                                                IdentifierName("SilkMarshal"),
+                                                IdentifierName("DelegateToPtr")
+                                            ),
+                                            ArgumentList(
+                                                SingletonSeparatedList(
+                                                    Argument(IdentifierName("proc"))
+                                                )
+                                            )
                                         )
                                     )
                                 )
                             )
-                        )
-                        .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                    MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "Dispose")
-                        .WithExpressionBody(
-                            ArrowExpressionClause(
-                                InvocationExpression(
-                                    MemberAccessExpression(
-                                        SyntaxKind.SimpleMemberAccessExpression,
-                                        IdentifierName("SilkMarshal"),
-                                        IdentifierName("Free")
-                                    ),
-                                    ArgumentList(
-                                        SingletonSeparatedList(Argument(IdentifierName("_pointer")))
+                            .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                        MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "Dispose")
+                            .WithExpressionBody(
+                                ArrowExpressionClause(
+                                    InvocationExpression(
+                                        MemberAccessExpression(
+                                            SyntaxKind.SimpleMemberAccessExpression,
+                                            IdentifierName("SilkMarshal"),
+                                            IdentifierName("Free")
+                                        ),
+                                        ArgumentList(
+                                            SingletonSeparatedList(
+                                                Argument(IdentifierName("_pointer"))
+                                            )
+                                        )
                                     )
                                 )
                             )
-                        )
-                        .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                    ConversionOperatorDeclaration(
-                            Token(SyntaxKind.ImplicitKeyword),
-                            IdentifierName(pfnName)
-                        )
-                        .WithParameterList(
-                            ParameterList(
-                                SingletonSeparatedList(
-                                    Parameter(Identifier("pfn")).WithType(rawPfn)
-                                )
+                            .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                        ConversionOperatorDeclaration(
+                                Token(SyntaxKind.ImplicitKeyword),
+                                IdentifierName(pfnName)
                             )
-                        )
-                        .WithModifiers(
-                            TokenList(
-                                Token(SyntaxKind.PublicKeyword),
-                                Token(SyntaxKind.StaticKeyword)
-                            )
-                        )
-                        .WithExpressionBody(
-                            ArrowExpressionClause(
-                                ImplicitObjectCreationExpression(
-                                    ArgumentList(
-                                        SingletonSeparatedList(Argument(IdentifierName("pfn")))
-                                    ),
-                                    null
-                                )
-                            )
-                        )
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                    ConversionOperatorDeclaration(Token(SyntaxKind.ImplicitKeyword), rawPfn)
-                        .WithParameterList(
-                            ParameterList(
-                                SingletonSeparatedList(
-                                    Parameter(Identifier("pfn")).WithType(IdentifierName(pfnName))
-                                )
-                            )
-                        )
-                        .WithModifiers(
-                            TokenList(
-                                Token(SyntaxKind.PublicKeyword),
-                                Token(SyntaxKind.StaticKeyword)
-                            )
-                        )
-                        .WithExpressionBody(
-                            ArrowExpressionClause(
-                                CastExpression(
-                                    rawPfn,
-                                    MemberAccessExpression(
-                                        SyntaxKind.SimpleMemberAccessExpression,
-                                        IdentifierName("pfn"),
-                                        IdentifierName("_pointer")
+                            .WithParameterList(
+                                ParameterList(
+                                    SingletonSeparatedList(
+                                        Parameter(Identifier("pfn")).WithType(rawPfn)
                                     )
                                 )
                             )
-                        )
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                    // TODO invoke method?
-                ])
+                            .WithModifiers(
+                                TokenList(
+                                    Token(SyntaxKind.PublicKeyword),
+                                    Token(SyntaxKind.StaticKeyword)
+                                )
+                            )
+                            .WithExpressionBody(
+                                ArrowExpressionClause(
+                                    ImplicitObjectCreationExpression(
+                                        ArgumentList(
+                                            SingletonSeparatedList(Argument(IdentifierName("pfn")))
+                                        ),
+                                        null
+                                    )
+                                )
+                            )
+                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                        ConversionOperatorDeclaration(Token(SyntaxKind.ImplicitKeyword), rawPfn)
+                            .WithParameterList(
+                                ParameterList(
+                                    SingletonSeparatedList(
+                                        Parameter(Identifier("pfn"))
+                                            .WithType(IdentifierName(pfnName))
+                                    )
+                                )
+                            )
+                            .WithModifiers(
+                                TokenList(
+                                    Token(SyntaxKind.PublicKeyword),
+                                    Token(SyntaxKind.StaticKeyword)
+                                )
+                            )
+                            .WithExpressionBody(
+                                ArrowExpressionClause(
+                                    CastExpression(
+                                        rawPfn,
+                                        MemberAccessExpression(
+                                            SyntaxKind.SimpleMemberAccessExpression,
+                                            IdentifierName("pfn"),
+                                            IdentifierName("_pointer")
+                                        )
+                                    )
+                                )
+                            )
+                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                        // TODO invoke method?
+                    ]
+                )
             );
 
         var @delegate = DelegateDeclaration(

--- a/sources/SilkTouch/SilkTouch/Mods/ExtractNestedTyping.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/ExtractNestedTyping.cs
@@ -70,7 +70,8 @@ public partial class ExtractNestedTyping(ILogger<ExtractNestedTyping> logger) : 
         foreach (var docId in project.DocumentIds)
         {
             var doc =
-                project.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
+                project.GetDocument(docId)
+                ?? throw new InvalidOperationException("Document missing");
             var (fname, node) = (doc.RelativePath(), await doc.GetSyntaxRootAsync(ct));
             if (fname is null)
             {
@@ -92,26 +93,30 @@ public partial class ExtractNestedTyping(ILogger<ExtractNestedTyping> logger) : 
             foreach (var newStruct in rewriter.ExtractedNestedStructs)
             {
                 // Add new documents for each nested struct
-                 project = project.AddDocument(
-                    $"{newStruct.Identifier}.gen.cs",
-                    CompilationUnit()
-                        .WithMembers(
-                            rewriter.Namespace is not null
-                                ? SingletonList<MemberDeclarationSyntax>(
-                                    FileScopedNamespaceDeclaration(
-                                            ModUtils.NamespaceIntoIdentifierName(rewriter.Namespace)
-                                        )
-                                        .WithMembers(
-                                            SingletonList<MemberDeclarationSyntax>(newStruct)
-                                        )
-                                )
-                                : SingletonList<MemberDeclarationSyntax>(newStruct)
+                project = project
+                    .AddDocument(
+                        $"{newStruct.Identifier}.gen.cs",
+                        CompilationUnit()
+                            .WithMembers(
+                                rewriter.Namespace is not null
+                                    ? SingletonList<MemberDeclarationSyntax>(
+                                        FileScopedNamespaceDeclaration(
+                                                ModUtils.NamespaceIntoIdentifierName(
+                                                    rewriter.Namespace
+                                                )
+                                            )
+                                            .WithMembers(
+                                                SingletonList<MemberDeclarationSyntax>(newStruct)
+                                            )
+                                    )
+                                    : SingletonList<MemberDeclarationSyntax>(newStruct)
+                            )
+                            .NormalizeWhitespace(),
+                        filePath: project.FullPath(
+                            $"{fname.AsSpan()[..fname.LastIndexOf('/')]}/{newStruct.Identifier}.gen.cs"
                         )
-                        .NormalizeWhitespace(),
-                    filePath: project.FullPath(
-                        $"{fname.AsSpan()[..fname.LastIndexOf('/')]}/{newStruct.Identifier}.gen.cs"
                     )
-                ).Project;
+                    .Project;
             }
 
             rewriter.File = null;
@@ -124,25 +129,21 @@ public partial class ExtractNestedTyping(ILogger<ExtractNestedTyping> logger) : 
         var extractedFunctionPointers = rewriter
             .FunctionPointerTypes.Values //.Where(x => x.IsUnique)
             .SelectMany(x =>
-                (IEnumerable<(
-                    MemberDeclarationSyntax,
-                    string,
-                    HashSet<string>,
-                    HashSet<string>
-                    )>) [
-                    (
-                        x.Delegate,
-                        x.Delegate.Identifier.ToString(),
-                        x.ReferencingFileDirs,
-                        x.ReferencingNamespaces
-                    ),
-                    (
-                        x.Pfn,
-                        x.Pfn.Identifier.ToString(),
-                        x.ReferencingFileDirs,
-                        x.ReferencingNamespaces
-                    ),
-                ]
+                (IEnumerable<(MemberDeclarationSyntax, string, HashSet<string>, HashSet<string>)>)
+                    [
+                        (
+                            x.Delegate,
+                            x.Delegate.Identifier.ToString(),
+                            x.ReferencingFileDirs,
+                            x.ReferencingNamespaces
+                        ),
+                        (
+                            x.Pfn,
+                            x.Pfn.Identifier.ToString(),
+                            x.ReferencingFileDirs,
+                            x.ReferencingNamespaces
+                        ),
+                    ]
             )
             .Concat(
                 enums.Select(x =>
@@ -153,7 +154,8 @@ public partial class ExtractNestedTyping(ILogger<ExtractNestedTyping> logger) : 
                         x.Value.Item3
                     )
                 )
-            ).ToList();
+            )
+            .ToList();
 
         foreach (var (typeDecl, identifier, fileDirs, namespaces) in extractedFunctionPointers)
         {
@@ -508,13 +510,24 @@ public partial class ExtractNestedTyping(ILogger<ExtractNestedTyping> logger) : 
                 var (pfn, @delegate) = CreateFunctionPointerTypes(
                     currentNativeTypeName,
                     $"{currentNativeTypeName}Delegate",
-                    (currentNativeTypeName == fallback
-                        ? SingletonList(AttributeList(SingletonSeparatedList(Attribute(IdentifierName("Transformed")))))
-                        : default)
-                        .WithNativeName(currentNativeTypeName),
-                    (currentNativeTypeName == fallback
-                        ? SingletonList(AttributeList(SingletonSeparatedList(Attribute(IdentifierName("Transformed")))))
-                        : default)
+                    (
+                        currentNativeTypeName == fallback
+                            ? SingletonList(
+                                AttributeList(
+                                    SingletonSeparatedList(Attribute(IdentifierName("Transformed")))
+                                )
+                            )
+                            : default
+                    ).WithNativeName(currentNativeTypeName),
+                    (
+                        currentNativeTypeName == fallback
+                            ? SingletonList(
+                                AttributeList(
+                                    SingletonSeparatedList(Attribute(IdentifierName("Transformed")))
+                                )
+                            )
+                            : default
+                    )
                         .WithNativeName(currentNativeTypeName)
                         .AddNameSuffix("FunctionPointerDelegateType", "Delegate"),
                     node
@@ -779,156 +792,149 @@ public partial class ExtractNestedTyping(ILogger<ExtractNestedTyping> logger) : 
             )
             .WithAttributeLists(pfnAttrLists)
             .WithMembers(
-                List<MemberDeclarationSyntax>(
-                    [
-                        FieldDeclaration(
-                                VariableDeclaration(
-                                    PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword))),
-                                    SingletonSeparatedList(VariableDeclarator("_pointer"))
+                List<MemberDeclarationSyntax>([
+                    FieldDeclaration(
+                            VariableDeclaration(
+                                PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword))),
+                                SingletonSeparatedList(VariableDeclarator("_pointer"))
+                            )
+                        )
+                        .WithModifiers(
+                            TokenList(
+                                Token(SyntaxKind.PrivateKeyword),
+                                Token(SyntaxKind.ReadOnlyKeyword)
+                            )
+                        ),
+                    PropertyDeclaration(rawPfn, "Handle")
+                        .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                        .WithExpressionBody(
+                            ArrowExpressionClause(
+                                CastExpression(rawPfn, IdentifierName("_pointer"))
+                            )
+                        )
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                    ConstructorDeclaration(pfnName)
+                        .WithParameterList(
+                            ParameterList(
+                                SingletonSeparatedList(
+                                    Parameter(Identifier("ptr")).WithType(rawPfn)
                                 )
                             )
-                            .WithModifiers(
-                                TokenList(
-                                    Token(SyntaxKind.PrivateKeyword),
-                                    Token(SyntaxKind.ReadOnlyKeyword)
-                                )
-                            ),
-                        PropertyDeclaration(rawPfn, "Handle")
-                            .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
-                            .WithExpressionBody(
-                                ArrowExpressionClause(
-                                    CastExpression(rawPfn, IdentifierName("_pointer"))
+                        )
+                        .WithExpressionBody(
+                            ArrowExpressionClause(
+                                AssignmentExpression(
+                                    SyntaxKind.SimpleAssignmentExpression,
+                                    IdentifierName("_pointer"),
+                                    IdentifierName("ptr")
                                 )
                             )
-                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                        ConstructorDeclaration(pfnName)
-                            .WithParameterList(
-                                ParameterList(
-                                    SingletonSeparatedList(
-                                        Parameter(Identifier("ptr")).WithType(rawPfn)
-                                    )
+                        )
+                        .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                    ConstructorDeclaration(pfnName)
+                        .WithParameterList(
+                            ParameterList(
+                                SingletonSeparatedList(
+                                    Parameter(Identifier("proc"))
+                                        .WithType(IdentifierName(delegateName))
                                 )
                             )
-                            .WithExpressionBody(
-                                ArrowExpressionClause(
-                                    AssignmentExpression(
-                                        SyntaxKind.SimpleAssignmentExpression,
-                                        IdentifierName("_pointer"),
-                                        IdentifierName("ptr")
-                                    )
-                                )
-                            )
-                            .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
-                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                        ConstructorDeclaration(pfnName)
-                            .WithParameterList(
-                                ParameterList(
-                                    SingletonSeparatedList(
-                                        Parameter(Identifier("proc"))
-                                            .WithType(IdentifierName(delegateName))
-                                    )
-                                )
-                            )
-                            .WithExpressionBody(
-                                ArrowExpressionClause(
-                                    AssignmentExpression(
-                                        SyntaxKind.SimpleAssignmentExpression,
-                                        IdentifierName("_pointer"),
-                                        InvocationExpression(
-                                            MemberAccessExpression(
-                                                SyntaxKind.SimpleMemberAccessExpression,
-                                                IdentifierName("SilkMarshal"),
-                                                IdentifierName("DelegateToPtr")
-                                            ),
-                                            ArgumentList(
-                                                SingletonSeparatedList(
-                                                    Argument(IdentifierName("proc"))
-                                                )
-                                            )
-                                        )
-                                    )
-                                )
-                            )
-                            .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
-                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                        MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "Dispose")
-                            .WithExpressionBody(
-                                ArrowExpressionClause(
+                        )
+                        .WithExpressionBody(
+                            ArrowExpressionClause(
+                                AssignmentExpression(
+                                    SyntaxKind.SimpleAssignmentExpression,
+                                    IdentifierName("_pointer"),
                                     InvocationExpression(
                                         MemberAccessExpression(
                                             SyntaxKind.SimpleMemberAccessExpression,
                                             IdentifierName("SilkMarshal"),
-                                            IdentifierName("Free")
+                                            IdentifierName("DelegateToPtr")
                                         ),
                                         ArgumentList(
-                                            SingletonSeparatedList(
-                                                Argument(IdentifierName("_pointer"))
-                                            )
+                                            SingletonSeparatedList(Argument(IdentifierName("proc")))
                                         )
                                     )
                                 )
                             )
-                            .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
-                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                        ConversionOperatorDeclaration(
-                                Token(SyntaxKind.ImplicitKeyword),
-                                IdentifierName(pfnName)
-                            )
-                            .WithParameterList(
-                                ParameterList(
-                                    SingletonSeparatedList(
-                                        Parameter(Identifier("pfn")).WithType(rawPfn)
+                        )
+                        .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                    MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "Dispose")
+                        .WithExpressionBody(
+                            ArrowExpressionClause(
+                                InvocationExpression(
+                                    MemberAccessExpression(
+                                        SyntaxKind.SimpleMemberAccessExpression,
+                                        IdentifierName("SilkMarshal"),
+                                        IdentifierName("Free")
+                                    ),
+                                    ArgumentList(
+                                        SingletonSeparatedList(Argument(IdentifierName("_pointer")))
                                     )
                                 )
                             )
-                            .WithModifiers(
-                                TokenList(
-                                    Token(SyntaxKind.PublicKeyword),
-                                    Token(SyntaxKind.StaticKeyword)
+                        )
+                        .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                    ConversionOperatorDeclaration(
+                            Token(SyntaxKind.ImplicitKeyword),
+                            IdentifierName(pfnName)
+                        )
+                        .WithParameterList(
+                            ParameterList(
+                                SingletonSeparatedList(
+                                    Parameter(Identifier("pfn")).WithType(rawPfn)
                                 )
                             )
-                            .WithExpressionBody(
-                                ArrowExpressionClause(
-                                    ImplicitObjectCreationExpression(
-                                        ArgumentList(
-                                            SingletonSeparatedList(Argument(IdentifierName("pfn")))
-                                        ),
-                                        null
+                        )
+                        .WithModifiers(
+                            TokenList(
+                                Token(SyntaxKind.PublicKeyword),
+                                Token(SyntaxKind.StaticKeyword)
+                            )
+                        )
+                        .WithExpressionBody(
+                            ArrowExpressionClause(
+                                ImplicitObjectCreationExpression(
+                                    ArgumentList(
+                                        SingletonSeparatedList(Argument(IdentifierName("pfn")))
+                                    ),
+                                    null
+                                )
+                            )
+                        )
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                    ConversionOperatorDeclaration(Token(SyntaxKind.ImplicitKeyword), rawPfn)
+                        .WithParameterList(
+                            ParameterList(
+                                SingletonSeparatedList(
+                                    Parameter(Identifier("pfn")).WithType(IdentifierName(pfnName))
+                                )
+                            )
+                        )
+                        .WithModifiers(
+                            TokenList(
+                                Token(SyntaxKind.PublicKeyword),
+                                Token(SyntaxKind.StaticKeyword)
+                            )
+                        )
+                        .WithExpressionBody(
+                            ArrowExpressionClause(
+                                CastExpression(
+                                    rawPfn,
+                                    MemberAccessExpression(
+                                        SyntaxKind.SimpleMemberAccessExpression,
+                                        IdentifierName("pfn"),
+                                        IdentifierName("_pointer")
                                     )
                                 )
                             )
-                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                        ConversionOperatorDeclaration(Token(SyntaxKind.ImplicitKeyword), rawPfn)
-                            .WithParameterList(
-                                ParameterList(
-                                    SingletonSeparatedList(
-                                        Parameter(Identifier("pfn"))
-                                            .WithType(IdentifierName(pfnName))
-                                    )
-                                )
-                            )
-                            .WithModifiers(
-                                TokenList(
-                                    Token(SyntaxKind.PublicKeyword),
-                                    Token(SyntaxKind.StaticKeyword)
-                                )
-                            )
-                            .WithExpressionBody(
-                                ArrowExpressionClause(
-                                    CastExpression(
-                                        rawPfn,
-                                        MemberAccessExpression(
-                                            SyntaxKind.SimpleMemberAccessExpression,
-                                            IdentifierName("pfn"),
-                                            IdentifierName("_pointer")
-                                        )
-                                    )
-                                )
-                            )
-                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                        // TODO invoke method?
-                    ]
-                )
+                        )
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                    // TODO invoke method?
+                ])
             );
 
         var @delegate = DelegateDeclaration(

--- a/sources/SilkTouch/SilkTouch/Mods/InterceptNativeFunctions.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/InterceptNativeFunctions.cs
@@ -104,27 +104,31 @@ public class InterceptNativeFunctions(
                         )
                     )
                     .AddNativeFunction(node)
-                    .WithModifiers([
-                        .. node.Modifiers.Where(x => x.Kind() is not SyntaxKind.ExternKeyword),
-                        Token(SyntaxKind.PartialKeyword),
-                    ])
+                    .WithModifiers(
+                        [
+                            .. node.Modifiers.Where(x => x.Kind() is not SyntaxKind.ExternKeyword),
+                            Token(SyntaxKind.PartialKeyword),
+                        ]
+                    )
                     .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
             );
 
             node = node.WithRenameSafeAttributeLists()
                 .WithIdentifier(Identifier($"{node.Identifier}Internal"))
-                .WithModifiers([
-                    Token(SyntaxKind.PrivateKeyword),
-                    .. node.Modifiers.Where(x =>
-                        x.Kind()
-                            is not (
-                                SyntaxKind.PrivateKeyword
-                                or SyntaxKind.PublicKeyword
-                                or SyntaxKind.InternalKeyword
-                                or SyntaxKind.ProtectedKeyword
-                            )
-                    ),
-                ]);
+                .WithModifiers(
+                    [
+                        Token(SyntaxKind.PrivateKeyword),
+                        .. node.Modifiers.Where(x =>
+                            x.Kind()
+                                is not (
+                                    SyntaxKind.PrivateKeyword
+                                    or SyntaxKind.PublicKeyword
+                                    or SyntaxKind.InternalKeyword
+                                    or SyntaxKind.ProtectedKeyword
+                                )
+                        ),
+                    ]
+                );
 
             return node.WithAttributeLists(
                 node.AttributeLists.AddNameSuffix("InterceptedFunction", "Internal")

--- a/sources/SilkTouch/SilkTouch/Mods/InterceptNativeFunctions.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/InterceptNativeFunctions.cs
@@ -104,34 +104,31 @@ public class InterceptNativeFunctions(
                         )
                     )
                     .AddNativeFunction(node)
-                    .WithModifiers(
-                        [
-                            .. node.Modifiers.Where(x => x.Kind() is not SyntaxKind.ExternKeyword),
-                            Token(SyntaxKind.PartialKeyword),
-                        ]
-                    )
+                    .WithModifiers([
+                        .. node.Modifiers.Where(x => x.Kind() is not SyntaxKind.ExternKeyword),
+                        Token(SyntaxKind.PartialKeyword),
+                    ])
                     .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
             );
 
             node = node.WithRenameSafeAttributeLists()
                 .WithIdentifier(Identifier($"{node.Identifier}Internal"))
-                .WithModifiers(
-                    [
-                        Token(SyntaxKind.PrivateKeyword),
-                        .. node.Modifiers.Where(x =>
-                            x.Kind()
-                                is not (
-                                    SyntaxKind.PrivateKeyword
-                                    or SyntaxKind.PublicKeyword
-                                    or SyntaxKind.InternalKeyword
-                                    or SyntaxKind.ProtectedKeyword
-                                )
-                        ),
-                    ]
-                );
+                .WithModifiers([
+                    Token(SyntaxKind.PrivateKeyword),
+                    .. node.Modifiers.Where(x =>
+                        x.Kind()
+                            is not (
+                                SyntaxKind.PrivateKeyword
+                                or SyntaxKind.PublicKeyword
+                                or SyntaxKind.InternalKeyword
+                                or SyntaxKind.ProtectedKeyword
+                            )
+                    ),
+                ]);
 
             return node.WithAttributeLists(
-                node.AttributeLists.AddNameSuffix("InterceptedFunction", "Internal"));
+                node.AttributeLists.AddNameSuffix("InterceptedFunction", "Internal")
+            );
         }
     }
 }

--- a/sources/SilkTouch/SilkTouch/Mods/MarkNativeNames.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/MarkNativeNames.cs
@@ -34,10 +34,11 @@ public class MarkNativeNames : IMod
         var rewriter = new Rewriter();
         foreach (var docId in proj.DocumentIds)
         {
-            var doc = proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
+            var doc =
+                proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
                 rewriter.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
-                ?? throw new InvalidOperationException("Visit returned null.")
+                    ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }
 
@@ -46,7 +47,10 @@ public class MarkNativeNames : IMod
 
     private class Rewriter : ModCSharpSyntaxRewriter
     {
-        private SyntaxList<AttributeListSyntax> TryAddNativeNameAttribute(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken identifier)
+        private SyntaxList<AttributeListSyntax> TryAddNativeNameAttribute(
+            SyntaxList<AttributeListSyntax> attributeLists,
+            SyntaxToken identifier
+        )
         {
             if (attributeLists.TryGetNativeName(out _))
             {
@@ -61,7 +65,9 @@ public class MarkNativeNames : IMod
         /// <inheritdoc />
         public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
         {
-            node = node.WithAttributeLists(TryAddNativeNameAttribute(node.AttributeLists, node.Identifier));
+            node = node.WithAttributeLists(
+                TryAddNativeNameAttribute(node.AttributeLists, node.Identifier)
+            );
             node = (StructDeclarationSyntax)base.VisitStructDeclaration(node)!;
             return node;
         }
@@ -69,7 +75,9 @@ public class MarkNativeNames : IMod
         /// <inheritdoc />
         public override SyntaxNode VisitEnumDeclaration(EnumDeclarationSyntax node)
         {
-            node = node.WithAttributeLists(TryAddNativeNameAttribute(node.AttributeLists, node.Identifier));
+            node = node.WithAttributeLists(
+                TryAddNativeNameAttribute(node.AttributeLists, node.Identifier)
+            );
             node = (EnumDeclarationSyntax)base.VisitEnumDeclaration(node)!;
             return node;
         }
@@ -79,7 +87,9 @@ public class MarkNativeNames : IMod
         /// <inheritdoc />
         public override SyntaxNode VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
         {
-            node = node.WithAttributeLists(TryAddNativeNameAttribute(node.AttributeLists, node.Identifier));
+            node = node.WithAttributeLists(
+                TryAddNativeNameAttribute(node.AttributeLists, node.Identifier)
+            );
             node = (EnumMemberDeclarationSyntax)base.VisitEnumMemberDeclaration(node)!;
             return node;
         }
@@ -87,7 +97,9 @@ public class MarkNativeNames : IMod
         /// <inheritdoc />
         public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
         {
-            node = node.WithAttributeLists(TryAddNativeNameAttribute(node.AttributeLists, node.Identifier));
+            node = node.WithAttributeLists(
+                TryAddNativeNameAttribute(node.AttributeLists, node.Identifier)
+            );
             node = (PropertyDeclarationSyntax)base.VisitPropertyDeclaration(node)!;
             return node;
         }
@@ -95,7 +107,9 @@ public class MarkNativeNames : IMod
         /// <inheritdoc />
         public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
         {
-            node = node.WithAttributeLists(TryAddNativeNameAttribute(node.AttributeLists, node.Identifier));
+            node = node.WithAttributeLists(
+                TryAddNativeNameAttribute(node.AttributeLists, node.Identifier)
+            );
             node = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!;
             return node;
         }
@@ -105,7 +119,12 @@ public class MarkNativeNames : IMod
         {
             // This just uses the first declared field's identifier in cases where a field declares multiple variables
             // Eg: int a, b;
-            node = node.WithAttributeLists(TryAddNativeNameAttribute(node.AttributeLists, node.Declaration.Variables.First().Identifier));
+            node = node.WithAttributeLists(
+                TryAddNativeNameAttribute(
+                    node.AttributeLists,
+                    node.Declaration.Variables.First().Identifier
+                )
+            );
             node = (FieldDeclarationSyntax)base.VisitFieldDeclaration(node)!;
             return node;
         }

--- a/sources/SilkTouch/SilkTouch/Mods/MixKhronosData.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/MixKhronosData.cs
@@ -279,32 +279,33 @@ public partial class MixKhronosData(
             .Select(x => x.Profile)
             .ToHashSet();
 
-        job.Vendors.UnionWith([
-            .. xml.Element("registry")
-                ?.Element("tags")
-                ?.Elements("tag")
-                .Attributes("name")
-                .Select(x => x.Value)
-                ?? [],
-            .. currentConfig.NonStandardExtensionNomenclature
-                ? []
-                : xml.Element("registry")
-                    ?.Element("extensions")
-                    ?.Elements("extension")
-                    // Only include vendors who have extensions that match a declared profile
-                    // This is mainly to exclude extensions that are declared as supported="disabled"
-                    .Where(ext =>
-                    {
-                        var supportedProfiles = ext.Attribute("supported")?.Value.Split("|") ?? [];
-                        return profiles.Intersect(supportedProfiles).Any();
-                    })
+        job.Vendors.UnionWith(
+            [
+                .. xml.Element("registry")
+                    ?.Element("tags")
+                    ?.Elements("tag")
                     .Attributes("name")
-                    // Extract the second part from the extension name
-                    // Eg: GL_NV_command_list -> NV
-                    .Select(name => name.Value.Split('_')[1].ToUpper())
-                    ?? [],
-            .. currentConfig.Vendors ?? [],
-        ]);
+                    .Select(x => x.Value) ?? [],
+                .. currentConfig.NonStandardExtensionNomenclature
+                    ? []
+                    : xml.Element("registry")
+                        ?.Element("extensions")
+                        ?.Elements("extension")
+                        // Only include vendors who have extensions that match a declared profile
+                        // This is mainly to exclude extensions that are declared as supported="disabled"
+                        .Where(ext =>
+                        {
+                            var supportedProfiles =
+                                ext.Attribute("supported")?.Value.Split("|") ?? [];
+                            return profiles.Intersect(supportedProfiles).Any();
+                        })
+                        .Attributes("name")
+                        // Extract the second part from the extension name
+                        // Eg: GL_NV_command_list -> NV
+                        .Select(name => name.Value.Split('_')[1].ToUpper()) ?? [],
+                .. currentConfig.Vendors ?? [],
+            ]
+        );
 
         job.DeprecatedAliases = xml.Descendants()
             .Where(x =>
@@ -584,8 +585,7 @@ public partial class MixKhronosData(
                         )[0]
                 )
                 .ThenBy(x => x.Attribute("number")?.Value, VersionComparer.Instance)
-                .ToArray()
-            ?? [];
+                .ToArray() ?? [];
 
         // Record the variations declared within those elements (OpenGL only atm)
         var profileVariations = new Dictionary<string, HashSet<string>>();
@@ -659,8 +659,7 @@ public partial class MixKhronosData(
                     ?.Value.Split(
                         _listSeparators,
                         StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
-                    )
-                ?? [];
+                    ) ?? [];
 
             // Evaluate all of the elements.
             for (var i = 0; i < allApis.Length; i++)
@@ -1133,8 +1132,7 @@ public partial class MixKhronosData(
                     ?.Value.Split(
                         _listSeparators,
                         StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
-                    )
-                ?? [];
+                    ) ?? [];
 
             foreach (var supportedApi in supportedApis)
             {
@@ -1612,7 +1610,8 @@ public partial class MixKhronosData(
                         .Distinct()
                         .Select((x, i) => (x, i))
                         .LastOrDefault()
-                        is (var n, 0)
+                        is
+                        (var n, 0)
                         ? n
                         : null;
 
@@ -1659,9 +1658,9 @@ public partial class MixKhronosData(
                                                         )
                                                         .WithAttributeLists(attributes)
                                                         .WithBaseList(
-                                                            BaseList([
-                                                                SimpleBaseType(baseTypeSyntax),
-                                                            ])
+                                                            BaseList(
+                                                                [SimpleBaseType(baseTypeSyntax)]
+                                                            )
                                                         )
                                                         .WithMembers(
                                                             SeparatedList(
@@ -1796,11 +1795,13 @@ public partial class MixKhronosData(
             if (node.Members.Any(m => job.DeprecatedAliases.Contains(m.Identifier.ValueText)))
             {
                 // Remove deprecated aliases
-                node = node.WithMembers([
-                    .. node.Members.Where(m =>
-                        !job.DeprecatedAliases.Contains(m.Identifier.ValueText)
-                    ),
-                ]);
+                node = node.WithMembers(
+                    [
+                        .. node.Members.Where(m =>
+                            !job.DeprecatedAliases.Contains(m.Identifier.ValueText)
+                        ),
+                    ]
+                );
             }
 
             if (job.Groups.TryGetValue(identifier, out var group) && group.KnownBitmask)
@@ -1826,11 +1827,13 @@ public partial class MixKhronosData(
             {
                 // Remove deprecated aliases
                 node = node.WithDeclaration(
-                    node.Declaration.WithVariables([
-                        .. node.Declaration.Variables.Where(v =>
-                            !job.DeprecatedAliases.Contains(v.Identifier.ValueText)
-                        ),
-                    ])
+                    node.Declaration.WithVariables(
+                        [
+                            .. node.Declaration.Variables.Where(v =>
+                                !job.DeprecatedAliases.Contains(v.Identifier.ValueText)
+                            ),
+                        ]
+                    )
                 );
 
                 if (node.Declaration.Variables.Count == 0)
@@ -2108,35 +2111,37 @@ public partial class MixKhronosData(
                 && canTrimImpliedVendors
             )
             {
-                node = node.WithMembers([
-                    .. node.Members.Select(member =>
-                    {
-                        if (
-                            member
-                                .AttributeLists.GetNativeNameOrDefault(member.Identifier)
-                                .EndsWith(typeVendor)
-                        )
+                node = node.WithMembers(
+                    [
+                        .. node.Members.Select(member =>
                         {
-                            // Identify for trimming
+                            if (
+                                member
+                                    .AttributeLists.GetNativeNameOrDefault(member.Identifier)
+                                    .EndsWith(typeVendor)
+                            )
+                            {
+                                // Identify for trimming
+                                return member.WithAttributeLists(
+                                    member.AttributeLists.AddNameSuffix(
+                                        "KhronosImpliedVendor",
+                                        typeVendor,
+                                        true
+                                    )
+                                );
+                            }
+
+                            // Default behavior - Identify, but not for trimming
                             return member.WithAttributeLists(
-                                member.AttributeLists.AddNameSuffix(
-                                    "KhronosImpliedVendor",
-                                    typeVendor,
-                                    true
+                                ProcessAndGetNewAttributes(
+                                    member.AttributeLists,
+                                    member.Identifier,
+                                    false
                                 )
                             );
-                        }
-
-                        // Default behavior - Identify, but not for trimming
-                        return member.WithAttributeLists(
-                            ProcessAndGetNewAttributes(
-                                member.AttributeLists,
-                                member.Identifier,
-                                false
-                            )
-                        );
-                    }),
-                ]);
+                        }),
+                    ]
+                );
             }
             else
             {

--- a/sources/SilkTouch/SilkTouch/Mods/MixKhronosData.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/MixKhronosData.cs
@@ -274,14 +274,18 @@ public partial class MixKhronosData(
         job.ApiSets = apiSets;
         job.SupportedApiProfiles = supportedApiProfiles;
 
-        var profiles = supportedApiProfiles.SelectMany(x => x.Value).Select(x => x.Profile).ToHashSet();
+        var profiles = supportedApiProfiles
+            .SelectMany(x => x.Value)
+            .Select(x => x.Profile)
+            .ToHashSet();
 
         job.Vendors.UnionWith([
             .. xml.Element("registry")
                 ?.Element("tags")
                 ?.Elements("tag")
                 .Attributes("name")
-                .Select(x => x.Value) ?? [],
+                .Select(x => x.Value)
+                ?? [],
             .. currentConfig.NonStandardExtensionNomenclature
                 ? []
                 : xml.Element("registry")
@@ -297,13 +301,17 @@ public partial class MixKhronosData(
                     .Attributes("name")
                     // Extract the second part from the extension name
                     // Eg: GL_NV_command_list -> NV
-                    .Select(name => name.Value.Split('_')[1].ToUpper()) ?? [],
+                    .Select(name => name.Value.Split('_')[1].ToUpper())
+                    ?? [],
             .. currentConfig.Vendors ?? [],
         ]);
 
         job.DeprecatedAliases = xml.Descendants()
-            .Where(x => x.Attribute("deprecated")?.Value == "aliased" && x.Attribute("name") != null)
-            .Select(x => x.Attribute("name")!.Value).ToHashSet();
+            .Where(x =>
+                x.Attribute("deprecated")?.Value == "aliased" && x.Attribute("name") != null
+            )
+            .Select(x => x.Attribute("name")!.Value)
+            .ToHashSet();
 
         ReadGroups(xml, job, job.Vendors);
 
@@ -360,33 +368,33 @@ public partial class MixKhronosData(
         var rewriter1 = new RewriterPhase1(jobData, logger);
         foreach (var docId in proj.DocumentIds)
         {
-            var doc = proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
+            var doc =
+                proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
                 rewriter1.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
-                ?? throw new InvalidOperationException("Visit returned null.")
+                    ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }
 
         // Add missing enum types
         foreach (var (filePath, node) in rewriter1.GetMissingEnums())
         {
-            proj = proj
-                .AddDocument(
-                    Path.GetFileName(filePath),
-                    node.NormalizeWhitespace(),
-                    filePath: proj.FullPath(filePath)
-                )
-                .Project;
+            proj = proj.AddDocument(
+                Path.GetFileName(filePath),
+                node.NormalizeWhitespace(),
+                filePath: proj.FullPath(filePath)
+            ).Project;
         }
 
         // Rewrite phase 2
         var rewriter2 = new RewriterPhase2(jobData, rewriter1);
         foreach (var docId in proj.DocumentIds)
         {
-            var doc = proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
+            var doc =
+                proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
                 rewriter2.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
-                ?? throw new InvalidOperationException("Visit returned null.")
+                    ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }
 
@@ -394,17 +402,19 @@ public partial class MixKhronosData(
         var rewriter3 = new RewriterPhase3(jobData, currentConfig);
         foreach (var docId in proj.DocumentIds)
         {
-            var doc = proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
+            var doc =
+                proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
                 rewriter3.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
-                ?? throw new InvalidOperationException("Visit returned null.")
+                    ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }
 
         // Rename documents to account for FlagBits/Flags differences
         foreach (var docId in proj.DocumentIds)
         {
-            var doc = proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
+            var doc =
+                proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             if (doc.FilePath == null)
             {
                 continue;
@@ -421,12 +431,20 @@ public partial class MixKhronosData(
     {
         var job = Jobs[key];
 
-        rsps = rsps.Select(rsp => rsp with
-        {
-            GeneratorConfiguration = rsp.GeneratorConfiguration.ToWrapper() with {
-                RemappedNames = rsp.GeneratorConfiguration.RemappedNames.Concat(job.AdditionalTypeRemappings).ToDictionary(),
-            },
-        }).ToList();
+        rsps = rsps.Select(rsp =>
+                rsp with
+                {
+                    GeneratorConfiguration = rsp.GeneratorConfiguration.ToWrapper() with
+                    {
+                        RemappedNames = rsp
+                            .GeneratorConfiguration.RemappedNames.Concat(
+                                job.AdditionalTypeRemappings
+                            )
+                            .ToDictionary(),
+                    },
+                }
+            )
+            .ToList();
 
         return Task.FromResult(rsps);
     }
@@ -566,7 +584,8 @@ public partial class MixKhronosData(
                         )[0]
                 )
                 .ThenBy(x => x.Attribute("number")?.Value, VersionComparer.Instance)
-                .ToArray() ?? [];
+                .ToArray()
+            ?? [];
 
         // Record the variations declared within those elements (OpenGL only atm)
         var profileVariations = new Dictionary<string, HashSet<string>>();
@@ -640,7 +659,8 @@ public partial class MixKhronosData(
                     ?.Value.Split(
                         _listSeparators,
                         StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
-                    ) ?? [];
+                    )
+                ?? [];
 
             // Evaluate all of the elements.
             for (var i = 0; i < allApis.Length; i++)
@@ -1113,7 +1133,8 @@ public partial class MixKhronosData(
                     ?.Value.Split(
                         _listSeparators,
                         StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
-                    ) ?? [];
+                    )
+                ?? [];
 
             foreach (var supportedApi in supportedApis)
             {
@@ -1222,8 +1243,10 @@ public partial class MixKhronosData(
             {
                 foreach (var name in (IEnumerable<string>)[current, .. previous])
                 {
-                    if (job.Groups.TryGetValue(name, out var group)
-                        && name == $"{group.Namespace}Enum")
+                    if (
+                        job.Groups.TryGetValue(name, out var group)
+                        && name == $"{group.Namespace}Enum"
+                    )
                     {
                         context.Names[original] = new CandidateNames(name, []);
                         break;
@@ -1491,7 +1514,11 @@ public partial class MixKhronosData(
         [NotNullWhen(true)] out IEnumerable<SupportedApiProfileAttribute>? metadata
     )
     {
-        if (jobKey is null || !Jobs.TryGetValue(jobKey, out var job) || job.SupportedApiProfiles is null)
+        if (
+            jobKey is null
+            || !Jobs.TryGetValue(jobKey, out var job)
+            || job.SupportedApiProfiles is null
+        )
         {
             metadata = null;
             return false;
@@ -1585,8 +1612,7 @@ public partial class MixKhronosData(
                         .Distinct()
                         .Select((x, i) => (x, i))
                         .LastOrDefault()
-                        is
-                        (var n, 0)
+                        is (var n, 0)
                         ? n
                         : null;
 
@@ -1604,8 +1630,8 @@ public partial class MixKhronosData(
                     AllKnownEnums.Add(groupName);
 
                     var attributes = SingletonList(
-                        AttributeList(
-                            [Attribute(IdentifierName("Transformed"))]));
+                        AttributeList([Attribute(IdentifierName("Transformed"))])
+                    );
 
                     if (groupInfo.NativeName != null)
                     {
@@ -1614,44 +1640,60 @@ public partial class MixKhronosData(
 
                     var baseTypeSyntax = ParseTypeName(baseType);
 
-                    results.Add((
-                        $"Enums/{groupName}.gen.cs",
-                        CompilationUnit()
-                            .WithMembers(
-                                SingletonList<MemberDeclarationSyntax>(
-                                    FileScopedNamespaceDeclaration(ModUtils.NamespaceIntoIdentifierName(ns))
-                                        .WithMembers(
-                                            SingletonList<MemberDeclarationSyntax>(
-                                                EnumDeclaration(groupName)
-                                                    .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
-                                                    .WithAttributeLists(attributes)
-                                                    .WithBaseList(BaseList([SimpleBaseType(baseTypeSyntax)]))
-                                                    .WithMembers(
-                                                        SeparatedList(
-                                                            groupInfo.Enums.Select(x =>
-                                                                EnumMemberDeclaration(x.Identifier.ToString())
-                                                                    .WithAttributeLists(
-                                                                        new SyntaxList<AttributeListSyntax>()
-                                                                        .WithNativeName(x.Identifier.Text))
-                                                                    .WithEqualsValue(
-                                                                        x.Initializer?.WithValue(
-                                                                            CheckedExpression(
-                                                                                SyntaxKind.UncheckedExpression,
-                                                                                CastExpression(
-                                                                                    baseTypeSyntax,
-                                                                                    x.Initializer.Value
+                    results.Add(
+                        (
+                            $"Enums/{groupName}.gen.cs",
+                            CompilationUnit()
+                                .WithMembers(
+                                    SingletonList<MemberDeclarationSyntax>(
+                                        FileScopedNamespaceDeclaration(
+                                                ModUtils.NamespaceIntoIdentifierName(ns)
+                                            )
+                                            .WithMembers(
+                                                SingletonList<MemberDeclarationSyntax>(
+                                                    EnumDeclaration(groupName)
+                                                        .WithModifiers(
+                                                            TokenList(
+                                                                Token(SyntaxKind.PublicKeyword)
+                                                            )
+                                                        )
+                                                        .WithAttributeLists(attributes)
+                                                        .WithBaseList(
+                                                            BaseList([
+                                                                SimpleBaseType(baseTypeSyntax),
+                                                            ])
+                                                        )
+                                                        .WithMembers(
+                                                            SeparatedList(
+                                                                groupInfo.Enums.Select(x =>
+                                                                    EnumMemberDeclaration(
+                                                                            x.Identifier.ToString()
+                                                                        )
+                                                                        .WithAttributeLists(
+                                                                            new SyntaxList<AttributeListSyntax>().WithNativeName(
+                                                                                x.Identifier.Text
+                                                                            )
+                                                                        )
+                                                                        .WithEqualsValue(
+                                                                            x.Initializer?.WithValue(
+                                                                                CheckedExpression(
+                                                                                    SyntaxKind.UncheckedExpression,
+                                                                                    CastExpression(
+                                                                                        baseTypeSyntax,
+                                                                                        x.Initializer.Value
+                                                                                    )
                                                                                 )
                                                                             )
                                                                         )
-                                                                    )
+                                                                )
                                                             )
                                                         )
-                                                    )
+                                                )
                                             )
-                                        )
+                                    )
                                 )
-                            )
-                    ));
+                        )
+                    );
                 }
             }
 
@@ -1673,8 +1715,10 @@ public partial class MixKhronosData(
 
             AllKnownEnums.Add(identifier);
 
-            if (job.Groups.TryGetValue(identifier, out _)
-                && !node.Ancestors().OfType<BaseTypeDeclarationSyntax>().Any())
+            if (
+                job.Groups.TryGetValue(identifier, out _)
+                && !node.Ancestors().OfType<BaseTypeDeclarationSyntax>().Any()
+            )
             {
                 AlreadyPresentGroups.Add(identifier);
             }
@@ -1685,8 +1729,10 @@ public partial class MixKhronosData(
         public override SyntaxNode? VisitFieldDeclaration(FieldDeclarationSyntax node)
         {
             // Only match constant fields
-            if (node.Declaration.Variables.Count != 1
-                || !node.Modifiers.Any(SyntaxKind.ConstKeyword))
+            if (
+                node.Declaration.Variables.Count != 1
+                || !node.Modifiers.Any(SyntaxKind.ConstKeyword)
+            )
             {
                 return base.VisitFieldDeclaration(node);
             }
@@ -1740,7 +1786,8 @@ public partial class MixKhronosData(
     /// </summary>
     private class RewriterPhase2(JobData job, RewriterPhase1 phase1) : CSharpSyntaxRewriter(true)
     {
-        public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node) => IdentifierName(node.Identifier.ToString().Replace("FlagBits", "Flags"));
+        public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node) =>
+            IdentifierName(node.Identifier.ToString().Replace("FlagBits", "Flags"));
 
         public override SyntaxNode? VisitEnumDeclaration(EnumDeclarationSyntax node)
         {
@@ -1750,7 +1797,9 @@ public partial class MixKhronosData(
             {
                 // Remove deprecated aliases
                 node = node.WithMembers([
-                    ..node.Members.Where(m => !job.DeprecatedAliases.Contains(m.Identifier.ValueText)),
+                    .. node.Members.Where(m =>
+                        !job.DeprecatedAliases.Contains(m.Identifier.ValueText)
+                    ),
                 ]);
             }
 
@@ -1758,8 +1807,8 @@ public partial class MixKhronosData(
             {
                 // Add [Flags] attribute
                 var flagsAttribute = AttributeList(
-                    SingletonSeparatedList(
-                        Attribute(IdentifierName("Flags"))));
+                    SingletonSeparatedList(Attribute(IdentifierName("Flags")))
+                );
 
                 node = node.WithAttributeLists(node.AttributeLists.Add(flagsAttribute));
             }
@@ -1769,12 +1818,20 @@ public partial class MixKhronosData(
 
         public override SyntaxNode? VisitFieldDeclaration(FieldDeclarationSyntax node)
         {
-            if (node.Declaration.Variables.Any(v => job.DeprecatedAliases.Contains(v.Identifier.ValueText)))
+            if (
+                node.Declaration.Variables.Any(v =>
+                    job.DeprecatedAliases.Contains(v.Identifier.ValueText)
+                )
+            )
             {
                 // Remove deprecated aliases
-                node = node.WithDeclaration(node.Declaration.WithVariables([
-                    ..node.Declaration.Variables.Where(v => !job.DeprecatedAliases.Contains(v.Identifier.ValueText)),
-                ]));
+                node = node.WithDeclaration(
+                    node.Declaration.WithVariables([
+                        .. node.Declaration.Variables.Where(v =>
+                            !job.DeprecatedAliases.Contains(v.Identifier.ValueText)
+                        ),
+                    ])
+                );
 
                 if (node.Declaration.Variables.Count == 0)
                 {
@@ -1816,7 +1873,10 @@ public partial class MixKhronosData(
         /// <remarks>
         /// This method is intentionally implemented in a naive manner to keep things simple.
         /// </remarks>
-        private bool TryGetManagedEnumType(SyntaxList<AttributeListSyntax> attributes, [NotNullWhen(true)] out string? managedName)
+        private bool TryGetManagedEnumType(
+            SyntaxList<AttributeListSyntax> attributes,
+            [NotNullWhen(true)] out string? managedName
+        )
         {
             managedName = null;
 
@@ -1853,7 +1913,12 @@ public partial class MixKhronosData(
     /// </remarks>
     private class RewriterPhase3(JobData job, Configuration config) : CSharpSyntaxRewriter
     {
-        private SyntaxList<AttributeListSyntax> ProcessAndGetNewAttributes(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken identifier, bool trimHandleSuffix, MethodDeclarationSyntax? methodDeclaration = null)
+        private SyntaxList<AttributeListSyntax> ProcessAndGetNewAttributes(
+            SyntaxList<AttributeListSyntax> attributeLists,
+            SyntaxToken identifier,
+            bool trimHandleSuffix,
+            MethodDeclarationSyntax? methodDeclaration = null
+        )
         {
             // Get the name of the identifier, preferring the native one if available
             // This name will be modified by the code below as different suffixes are identified
@@ -1886,14 +1951,21 @@ public partial class MixKhronosData(
                 }
             }
 
-            if (methodDeclaration != null && methodDeclaration.Parent.IsKind(SyntaxKind.ClassDeclaration))
+            if (
+                methodDeclaration != null
+                && methodDeclaration.Parent.IsKind(SyntaxKind.ClassDeclaration)
+            )
             {
                 // Try to identify non-vendor suffixes
                 foreach (var suffix in config.NonVendorSuffixes)
                 {
                     if (trimmedName.EndsWith(suffix))
                     {
-                        attributeLists = attributeLists.AddNameSuffix("KhronosNonVendor", suffix, true);
+                        attributeLists = attributeLists.AddNameSuffix(
+                            "KhronosNonVendor",
+                            suffix,
+                            true
+                        );
                         trimmedName = trimmedName[..^suffix.Length];
 
                         break;
@@ -1903,13 +1975,19 @@ public partial class MixKhronosData(
                 // Try to identify data type suffixes
                 if (config.IdentifyFunctionDataTypes)
                 {
-                    if (EndingsToTrim().Match(trimmedName) is { Success: true } match // Check if we end in a data type suffix
-                        && !EndingsNotToTrim().IsMatch(trimmedName)) // Check if the ending is excluded
+                    if (
+                        EndingsToTrim().Match(trimmedName) is { Success: true } match // Check if we end in a data type suffix
+                        && !EndingsNotToTrim().IsMatch(trimmedName)
+                    ) // Check if the ending is excluded
                     {
                         var dataTypeSuffix = trimmedName[match.Index..];
                         trimmedName = trimmedName[..match.Index];
 
-                        attributeLists = attributeLists.AddNameSuffix("KhronosFunctionDataType", dataTypeSuffix, true);
+                        attributeLists = attributeLists.AddNameSuffix(
+                            "KhronosFunctionDataType",
+                            dataTypeSuffix,
+                            true
+                        );
                     }
                 }
             }
@@ -1922,17 +2000,23 @@ public partial class MixKhronosData(
         public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
         {
             node = (StructDeclarationSyntax)base.VisitStructDeclaration(node)!;
-            return node.WithAttributeLists(ProcessAndGetNewAttributes(node.AttributeLists, node.Identifier, true));
+            return node.WithAttributeLists(
+                ProcessAndGetNewAttributes(node.AttributeLists, node.Identifier, true)
+            );
         }
 
         public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
         {
             var variable = node.Declaration.Variables.First();
-            return node.WithAttributeLists(ProcessAndGetNewAttributes(node.AttributeLists, variable.Identifier, false));
+            return node.WithAttributeLists(
+                ProcessAndGetNewAttributes(node.AttributeLists, variable.Identifier, false)
+            );
         }
 
         public override SyntaxNode VisitDelegateDeclaration(DelegateDeclarationSyntax node) =>
-            node.WithAttributeLists(ProcessAndGetNewAttributes(node.AttributeLists, node.Identifier, false));
+            node.WithAttributeLists(
+                ProcessAndGetNewAttributes(node.AttributeLists, node.Identifier, false)
+            );
 
         // Special case for enums since this code needs information about
         // the enum type name and its member names at the same time
@@ -1951,7 +2035,10 @@ public partial class MixKhronosData(
 
             // Figure out the enum's exclusive vendor
             var exclusiveVendor = groupInfo?.ExclusiveVendor ?? typeVendor;
-            if (exclusiveVendor == null || !node.Members.All(member => member.Identifier.Text.EndsWith(exclusiveVendor)))
+            if (
+                exclusiveVendor == null
+                || !node.Members.All(member => member.Identifier.Text.EndsWith(exclusiveVendor))
+            )
             {
                 // Not all enum members share the exclusive vendor
                 // This means the vendor suffix isn't actually exclusive
@@ -1966,7 +2053,8 @@ public partial class MixKhronosData(
                 // For example, SamplePatternEXT and SamplePatternSGIS are both enum types.
                 // Trimming both would cause conflicts.
                 // Trimming one but not the other would imply one is core and the other is not.
-                var hasMultipleVersions = job.Groups.Count(x => x.Key.StartsWith(typeName[..^typeVendor.Length])) > 1;
+                var hasMultipleVersions =
+                    job.Groups.Count(x => x.Key.StartsWith(typeName[..^typeVendor.Length])) > 1;
                 var isSafeToTrimType = !hasMultipleVersions;
 
                 // Identify the affix for trimming if the type vendor suffix does not match the identified exclusive vendor suffix
@@ -1984,7 +2072,9 @@ public partial class MixKhronosData(
             if (typeVendor != null)
             {
                 // Mark the type vendor suffix as identified
-                node = node.WithAttributeLists(node.AttributeLists.AddNameSuffix(vendorAffixType, typeVendor, true));
+                node = node.WithAttributeLists(
+                    node.AttributeLists.AddNameSuffix(vendorAffixType, typeVendor, true)
+                );
             }
 
             // Check if the enum contains unsuffixed members
@@ -2012,18 +2102,39 @@ public partial class MixKhronosData(
             var canTrimImpliedVendors = hasTypeSuffix && !containsUnsuffixedMembers;
 
             // See config option for more info and examples on what this does
-            if (config.IdentifyEnumMemberImpliedVendors && typeVendor != null && canTrimImpliedVendors)
+            if (
+                config.IdentifyEnumMemberImpliedVendors
+                && typeVendor != null
+                && canTrimImpliedVendors
+            )
             {
                 node = node.WithMembers([
-                    ..node.Members.Select(member => {
-                        if (member.AttributeLists.GetNativeNameOrDefault(member.Identifier).EndsWith(typeVendor))
+                    .. node.Members.Select(member =>
+                    {
+                        if (
+                            member
+                                .AttributeLists.GetNativeNameOrDefault(member.Identifier)
+                                .EndsWith(typeVendor)
+                        )
                         {
                             // Identify for trimming
-                            return member.WithAttributeLists(member.AttributeLists.AddNameSuffix("KhronosImpliedVendor", typeVendor, true));
+                            return member.WithAttributeLists(
+                                member.AttributeLists.AddNameSuffix(
+                                    "KhronosImpliedVendor",
+                                    typeVendor,
+                                    true
+                                )
+                            );
                         }
 
                         // Default behavior - Identify, but not for trimming
-                        return member.WithAttributeLists(ProcessAndGetNewAttributes(member.AttributeLists, member.Identifier, false));
+                        return member.WithAttributeLists(
+                            ProcessAndGetNewAttributes(
+                                member.AttributeLists,
+                                member.Identifier,
+                                false
+                            )
+                        );
                     }),
                 ]);
             }
@@ -2039,13 +2150,19 @@ public partial class MixKhronosData(
         // ----- Members -----
 
         public override SyntaxNode VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node) =>
-            node.WithAttributeLists(ProcessAndGetNewAttributes(node.AttributeLists, node.Identifier, false));
+            node.WithAttributeLists(
+                ProcessAndGetNewAttributes(node.AttributeLists, node.Identifier, false)
+            );
 
         public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node) =>
-            node.WithAttributeLists(ProcessAndGetNewAttributes(node.AttributeLists, node.Identifier, false));
+            node.WithAttributeLists(
+                ProcessAndGetNewAttributes(node.AttributeLists, node.Identifier, false)
+            );
 
         public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node) =>
-            node.WithAttributeLists(ProcessAndGetNewAttributes(node.AttributeLists, node.Identifier, false, node));
+            node.WithAttributeLists(
+                ProcessAndGetNewAttributes(node.AttributeLists, node.Identifier, false, node)
+            );
     }
 
     [SuppressMessage("ReSharper", "MoveLocalFunctionAfterJumpStatement")]
@@ -2190,7 +2307,11 @@ public partial class MixKhronosData(
             }
 
             // Some enum groups don't have members, meaning that the code above won't catch them
-            if (groupName != null && !IsUngroupable(groupName) && !data.Groups.ContainsKey(groupName))
+            if (
+                groupName != null
+                && !IsUngroupable(groupName)
+                && !data.Groups.ContainsKey(groupName)
+            )
             {
                 data.Groups[groupName] = new EnumGroup(
                     groupName,

--- a/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
@@ -971,29 +971,15 @@ public class PrettifyNames(
                         continue;
                     }
 
+                    var argumentList = attribute.ArgumentList;
                     if (
-                        attribute.ArgumentList != null
-                        && (
-                            attribute.ArgumentList.Arguments[0].Expression
-                            as LiteralExpressionSyntax
-                        )
-                            ?.Token
-                            .Value
-                            is string type
-                        && (
-                            attribute.ArgumentList.Arguments[1].Expression
-                            as LiteralExpressionSyntax
-                        )
-                            ?.Token
-                            .Value
-                            is string category
-                        && (
-                            attribute.ArgumentList.Arguments[2].Expression
-                            as LiteralExpressionSyntax
-                        )
-                            ?.Token
-                            .Value
-                            is string affix
+                        argumentList != null
+                        && argumentList.Arguments[0].Expression
+                            is LiteralExpressionSyntax { Token.Value: string type }
+                        && argumentList.Arguments[1].Expression
+                            is LiteralExpressionSyntax { Token.Value: string category }
+                        && argumentList.Arguments[2].Expression
+                            is LiteralExpressionSyntax { Token.Value: string affix }
                     )
                     {
                         affixes =

--- a/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
@@ -1268,8 +1268,7 @@ public class PrettifyNames(
                     node.AccessorList?.Accessors.Any(a =>
                         a.IsKind(SyntaxKind.SetAccessorDeclaration)
                         || a.IsKind(SyntaxKind.InitAccessorDeclaration)
-                    )
-                    ?? false;
+                    ) ?? false;
                 if (hasSetter)
                 {
                     if (!PrettifyOnlyTypes.TryGetValue(typeIdentifier, out var typeData))

--- a/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
@@ -136,9 +136,35 @@ public class PrettifyNames(
             foreach (var (name, (nonFunctions, functions)) in visitor.TrimmableTypes)
             {
                 newNames[name] = new RenamedType(
-                    ApplyPrettifyOnlyPipeline(null, name, cfg.NameOverrides, nameAffixer, nameTransformer),
-                    nonFunctions.ToDictionary(x => x, x => ApplyPrettifyOnlyPipeline(name, x, cfg.NameOverrides, nameAffixer, nameTransformer)),
-                    functions.ToDictionary(x => x.Name, x => ApplyPrettifyOnlyPipeline(name, x.Name, cfg.NameOverrides, nameAffixer, nameTransformer))
+                    ApplyPrettifyOnlyPipeline(
+                        null,
+                        name,
+                        cfg.NameOverrides,
+                        nameAffixer,
+                        nameTransformer
+                    ),
+                    nonFunctions.ToDictionary(
+                        x => x,
+                        x =>
+                            ApplyPrettifyOnlyPipeline(
+                                name,
+                                x,
+                                cfg.NameOverrides,
+                                nameAffixer,
+                                nameTransformer
+                            )
+                    ),
+                    functions.ToDictionary(
+                        x => x.Name,
+                        x =>
+                            ApplyPrettifyOnlyPipeline(
+                                name,
+                                x.Name,
+                                cfg.NameOverrides,
+                                nameAffixer,
+                                nameTransformer
+                            )
+                    )
                 );
             }
         }
@@ -188,10 +214,7 @@ public class PrettifyNames(
 
                 // Rename the "constants" i.e. all the consts/static readonlys in this type. These are treated
                 // individually because everything that isn't a constant or a function is only prettified instead of prettified & trimmed.
-                var constNames = consts.ToDictionary(
-                    x => x,
-                    x => new CandidateNames(x, [])
-                );
+                var constNames = consts.ToDictionary(x => x, x => new CandidateNames(x, []));
 
                 // Trim the constants.
                 Trim(
@@ -246,12 +269,28 @@ public class PrettifyNames(
         {
             if (!newNames.TryGetValue(typeName, out var renamedType))
             {
-                renamedType = new RenamedType(ApplyPrettifyOnlyPipeline(null, typeName, cfg.NameOverrides, nameAffixer, nameTransformer), [], []);
+                renamedType = new RenamedType(
+                    ApplyPrettifyOnlyPipeline(
+                        null,
+                        typeName,
+                        cfg.NameOverrides,
+                        nameAffixer,
+                        nameTransformer
+                    ),
+                    [],
+                    []
+                );
             }
 
             foreach (var memberName in memberNames)
             {
-                renamedType.NonFunctions[memberName] = ApplyPrettifyOnlyPipeline(typeName, memberName, cfg.NameOverrides, nameAffixer, nameTransformer);
+                renamedType.NonFunctions[memberName] = ApplyPrettifyOnlyPipeline(
+                    typeName,
+                    memberName,
+                    cfg.NameOverrides,
+                    nameAffixer,
+                    nameTransformer
+                );
             }
 
             newNames[typeName] = renamedType;
@@ -301,16 +340,16 @@ public class PrettifyNames(
 
         var comp =
             await proj.GetCompilationAsync(ct)
-            ?? throw new InvalidOperationException("Failed to obtain compilation for source project!");
+            ?? throw new InvalidOperationException(
+                "Failed to obtain compilation for source project!"
+            );
 
         await NameUtils.RenameAllAsync(
             ctx,
             newNames.SelectMany(x =>
             {
                 var nonFunctionConflicts = x
-                    .Value.NonFunctions.Values.Where(y =>
-                        x.Value.Functions.ContainsValue(y)
-                    )
+                    .Value.NonFunctions.Values.Where(y => x.Value.Functions.ContainsValue(y))
                     .ToHashSet();
                 return comp.GetSymbolsWithName(x.Key, SymbolFilter.Type, ct)
                     .OfType<ITypeSymbol>()
@@ -398,7 +437,9 @@ public class PrettifyNames(
 
             if (found)
             {
-                logger.LogError($"{originalName} -> {doc.Name} failed to rename file as a file already exists at {doc.FilePath}");
+                logger.LogError(
+                    $"{originalName} -> {doc.Name} failed to rename file as a file already exists at {doc.FilePath}"
+                );
             }
             else
             {
@@ -420,7 +461,8 @@ public class PrettifyNames(
         string name,
         Dictionary<string, string> nameOverrides,
         NameAffixer nameAffixer,
-        ICulturedStringTransformer nameTransformer)
+        ICulturedStringTransformer nameTransformer
+    )
     {
         // Check for overrides
         foreach (var (nativeName, overriddenName) in nameOverrides)
@@ -436,7 +478,10 @@ public class PrettifyNames(
                 // Check whether the override is for this type.
                 var span = nativeName.AsSpan();
                 var containerSpan = span[..span.IndexOf('.')];
-                if (!containerSpan.Equals("*", StringComparison.Ordinal) && !containerSpan.Equals(container, StringComparison.Ordinal))
+                if (
+                    !containerSpan.Equals("*", StringComparison.Ordinal)
+                    && !containerSpan.Equals(container, StringComparison.Ordinal)
+                )
                 {
                     continue;
                 }
@@ -487,7 +532,10 @@ public class PrettifyNames(
                 // Check whether the override is for this type.
                 var span = nativeName.AsSpan();
                 var containerSpan = span[..span.IndexOf('.')];
-                if (containerSpan.Equals("*", StringComparison.Ordinal) || containerSpan.Equals(context.Container, StringComparison.Ordinal))
+                if (
+                    containerSpan.Equals("*", StringComparison.Ordinal)
+                    || containerSpan.Equals(context.Container, StringComparison.Ordinal)
+                )
                 {
                     nameToAdd = span[(span.IndexOf('.') + 1)..].ToString();
                 }
@@ -559,7 +607,11 @@ public class PrettifyNames(
         // Keep track of the method discriminators to determine whether we have incompatible overloads that need to be
         // renamed. We keep track of the first trimming name so that we can add it to conflictingTrimmingNames when we
         // do discover a conflict (along with the trimming name of the actual conflict).
-        var methDiscrims = new Dictionary<string, (string? FirstTrimmingName, List<MethodDeclarationSyntax> Methods)>();
+        var methDiscrims =
+            new Dictionary<
+                string,
+                (string? FirstTrimmingName, List<MethodDeclarationSyntax> Methods)
+            >();
         var conflictingTrimmingNames = new HashSet<string>();
         while (namesToEval.GetEnumerator() is var e && e.MoveNext() && e.Current is var primary)
         {
@@ -699,7 +751,9 @@ public class PrettifyNames(
                         // Update the output name.
                         var firstSecondary =
                             context.Names[first].Secondary
-                            ?? throw new InvalidOperationException("More than one trimming name without secondary names.");
+                            ?? throw new InvalidOperationException(
+                                "More than one trimming name without secondary names."
+                            );
                         var firstNextPrimary = firstSecondary[^1];
                         firstSecondary.RemoveAt(firstSecondary.Count - 1);
                         context.Names[first] = new CandidateNames(firstNextPrimary, firstSecondary);
@@ -739,7 +793,9 @@ public class PrettifyNames(
                 // Conflict resolution! Update the output name.
                 var secondary =
                     context.Names[conflictingTrimmingName].Secondary
-                    ?? throw new InvalidOperationException("More than one trimming name without secondary names.");
+                    ?? throw new InvalidOperationException(
+                        "More than one trimming name without secondary names."
+                    );
                 var nextPrimary = secondary[^1];
                 secondary.RemoveAt(secondary.Count - 1);
                 context.Names[conflictingTrimmingName] = new CandidateNames(nextPrimary, secondary);
@@ -780,7 +836,7 @@ public class PrettifyNames(
             {
                 logger.LogWarning(
                     "{} (for {}) should use exclude-using-statics-for-enums as PrettifyNames does not resolve "
-                    + "conflicts with members of other types.",
+                        + "conflicts with members of other types.",
                     responseFile.FilePath,
                     key
                 );
@@ -789,7 +845,7 @@ public class PrettifyNames(
             {
                 logger.LogWarning(
                     "{} (for {}) should use exclude-using-statics-for-guid-members as PrettifyNames does not resolve "
-                    + "conflicts with members of other types.",
+                        + "conflicts with members of other types.",
                     responseFile.FilePath,
                     key
                 );
@@ -805,13 +861,27 @@ public class PrettifyNames(
     /// <param name="NewName">The new name of the type.</param>
     /// <param name="NonFunctions">The mappings from original names to new names of the type's non-function members.</param>
     /// <param name="Functions">The mappings from original names to new names of the type's function members.</param>
-    private record struct RenamedType(string NewName, Dictionary<string, string> NonFunctions, Dictionary<string, string> Functions);
+    private record struct RenamedType(
+        string NewName,
+        Dictionary<string, string> NonFunctions,
+        Dictionary<string, string> Functions
+    );
 
-    private record struct NameAffix(bool IsPrefix, string Category, string Affix, int DeclarationOrder);
+    private record struct NameAffix(
+        bool IsPrefix,
+        string Category,
+        string Affix,
+        int DeclarationOrder
+    );
 
     private record struct TypeData(List<string> NonFunctions, List<FunctionData> Functions);
+
     private record struct FunctionData(string Name, MethodDeclarationSyntax Syntax);
-    private record struct TypeAffixData(NameAffix[] TypeAffixes, Dictionary<string, NameAffix[]>? MemberAffixes);
+
+    private record struct TypeAffixData(
+        NameAffix[] TypeAffixes,
+        Dictionary<string, NameAffix[]>? MemberAffixes
+    );
 
     private class Visitor : CSharpSyntaxWalker
     {
@@ -859,7 +929,11 @@ public class PrettifyNames(
         /// <param name="Type">The class or struct's declaration syntax node.</param>
         /// <param name="NonFunctions">The names of the non-function members directly contained by the type.</param>
         /// <param name="Functions">The names of the function members directly contained by the type.</param>
-        private record struct TypeInProgress(TypeDeclarationSyntax Type, List<string> NonFunctions, List<FunctionData> Functions);
+        private record struct TypeInProgress(
+            TypeDeclarationSyntax Type,
+            List<string> NonFunctions,
+            List<FunctionData> Functions
+        );
 
         /// <summary>
         /// Represents an enum.
@@ -881,7 +955,10 @@ public class PrettifyNames(
             || _enumInProgress is not null
             || node.Ancestors().OfType<BaseTypeDeclarationSyntax>().Any();
 
-        private bool TryGetAffixData(SyntaxList<AttributeListSyntax> attributeLists, out NameAffix[] affixes)
+        private bool TryGetAffixData(
+            SyntaxList<AttributeListSyntax> attributeLists,
+            out NameAffix[] affixes
+        )
         {
             affixes = [];
             var declarationOrder = 0;
@@ -894,12 +971,36 @@ public class PrettifyNames(
                         continue;
                     }
 
-                    if (attribute.ArgumentList != null
-                        && (attribute.ArgumentList.Arguments[0].Expression as LiteralExpressionSyntax)?.Token.Value is string type
-                        && (attribute.ArgumentList.Arguments[1].Expression as LiteralExpressionSyntax)?.Token.Value is string category
-                        && (attribute.ArgumentList.Arguments[2].Expression as LiteralExpressionSyntax)?.Token.Value is string affix)
+                    if (
+                        attribute.ArgumentList != null
+                        && (
+                            attribute.ArgumentList.Arguments[0].Expression
+                            as LiteralExpressionSyntax
+                        )
+                            ?.Token
+                            .Value
+                            is string type
+                        && (
+                            attribute.ArgumentList.Arguments[1].Expression
+                            as LiteralExpressionSyntax
+                        )
+                            ?.Token
+                            .Value
+                            is string category
+                        && (
+                            attribute.ArgumentList.Arguments[2].Expression
+                            as LiteralExpressionSyntax
+                        )
+                            ?.Token
+                            .Value
+                            is string affix
+                    )
                     {
-                        affixes = [..affixes, new NameAffix(type == "Prefix", category, affix, declarationOrder)];
+                        affixes =
+                        [
+                            .. affixes,
+                            new NameAffix(type == "Prefix", category, affix, declarationOrder),
+                        ];
                         declarationOrder++;
                     }
                 }
@@ -908,7 +1009,10 @@ public class PrettifyNames(
             return affixes.Length != 0;
         }
 
-        private void ReportTypeAffixData(string typeIdentifier, SyntaxList<AttributeListSyntax> attributeLists)
+        private void ReportTypeAffixData(
+            string typeIdentifier,
+            SyntaxList<AttributeListSyntax> attributeLists
+        )
         {
             if (!TryGetAffixData(attributeLists, out var affixes))
             {
@@ -922,11 +1026,15 @@ public class PrettifyNames(
 
             AffixTypes[typeIdentifier] = typeAffixData with
             {
-                TypeAffixes = [..typeAffixData.TypeAffixes, ..affixes],
+                TypeAffixes = [.. typeAffixData.TypeAffixes, .. affixes],
             };
         }
 
-        private void ReportMemberAffixData(string typeIdentifier, string memberIdentifier, SyntaxList<AttributeListSyntax> attributeLists)
+        private void ReportMemberAffixData(
+            string typeIdentifier,
+            string memberIdentifier,
+            SyntaxList<AttributeListSyntax> attributeLists
+        )
         {
             if (!TryGetAffixData(attributeLists, out var affixData))
             {
@@ -972,7 +1080,11 @@ public class PrettifyNames(
                 TrimmableTypes.Add(identifier, typeData);
             }
 
-            typeData.NonFunctions.AddRange(_typeInProgress.Value.NonFunctions.Where(nonFunction => !typeData.NonFunctions.Contains(nonFunction)));
+            typeData.NonFunctions.AddRange(
+                _typeInProgress.Value.NonFunctions.Where(nonFunction =>
+                    !typeData.NonFunctions.Contains(nonFunction)
+                )
+            );
             typeData.Functions.AddRange(_typeInProgress.Value.Functions);
 
             _typeInProgress = null;
@@ -1004,7 +1116,11 @@ public class PrettifyNames(
                 TrimmableTypes.Add(identifier, typeData);
             }
 
-            typeData.NonFunctions.AddRange(_typeInProgress.Value.NonFunctions.Where(nonFunction => !typeData.NonFunctions.Contains(nonFunction)));
+            typeData.NonFunctions.AddRange(
+                _typeInProgress.Value.NonFunctions.Where(nonFunction =>
+                    !typeData.NonFunctions.Contains(nonFunction)
+                )
+            );
             typeData.Functions.AddRange(_typeInProgress.Value.Functions);
 
             _typeInProgress = null;
@@ -1080,7 +1196,9 @@ public class PrettifyNames(
         {
             // If it's not a constant then we only prettify
             // C constants are globally scoped and typically prefixed, so we trim in addition to prettifying
-            var prettifyOnly = !node.Modifiers.Any(SyntaxKind.ConstKeyword) && !node.Modifiers.Any(SyntaxKind.StaticKeyword);
+            var prettifyOnly =
+                !node.Modifiers.Any(SyntaxKind.ConstKeyword)
+                && !node.Modifiers.Any(SyntaxKind.StaticKeyword);
 
             if (node.Parent == _typeInProgress?.Type)
             {
@@ -1146,7 +1264,12 @@ public class PrettifyNames(
                 ReportMemberAffixData(typeIdentifier, memberIdentifier, node.AttributeLists);
 
                 // If it's not a constant then we only prettify.
-                var hasSetter = node.AccessorList?.Accessors.Any(a => a.IsKind(SyntaxKind.SetAccessorDeclaration) || a.IsKind(SyntaxKind.InitAccessorDeclaration)) ?? false;
+                var hasSetter =
+                    node.AccessorList?.Accessors.Any(a =>
+                        a.IsKind(SyntaxKind.SetAccessorDeclaration)
+                        || a.IsKind(SyntaxKind.InitAccessorDeclaration)
+                    )
+                    ?? false;
                 if (hasSetter)
                 {
                     if (!PrettifyOnlyTypes.TryGetValue(typeIdentifier, out var typeData))
@@ -1168,13 +1291,17 @@ public class PrettifyNames(
     private class RenameSafeAttributeListsRewriter : CSharpSyntaxRewriter
     {
         public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node) =>
-            ((MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!)
-                .WithRenameSafeAttributeLists();
+            (
+                (MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!
+            ).WithRenameSafeAttributeLists();
     }
 
     /// <param name="affixTypes">The affix data retrieved by the <see cref="Visitor"/>.</param>
     /// <param name="config">The configuration from <see cref="Configuration.Affixes"/>.</param>
-    private class NameAffixer(Dictionary<string, TypeAffixData> affixTypes, Dictionary<string, NameAffixConfiguration> config)
+    private class NameAffixer(
+        Dictionary<string, TypeAffixData> affixTypes,
+        Dictionary<string, NameAffixConfiguration> config
+    )
     {
         private static readonly NameAffixConfiguration _defaultConfig = new();
 
@@ -1189,7 +1316,12 @@ public class PrettifyNames(
         /// <param name="originalName">The original name of the identifier. Either the type name or the member name.</param>
         /// <param name="secondary">The list of secondary names. This should be null if used by <see cref="ApplyPrettifyOnlyPipeline"/>.</param>
         /// <returns>The new primary name.</returns>
-        public string RemoveAffixes(string primary, string? container, string originalName, List<string>? secondary)
+        public string RemoveAffixes(
+            string primary,
+            string? container,
+            string originalName,
+            List<string>? secondary
+        )
         {
             var affixes = GetAffixes(container, originalName);
             if (affixes.Length == 0)
@@ -1200,12 +1332,14 @@ public class PrettifyNames(
             var originalPrimary = primary;
 
             // Sort affixes so that the outer affixes are first
-            affixes.Sort(static (a, b) =>
-            {
-                // Sort by descending declaration order
-                // Lower declaration order means the affix is closer to the inside of the name
-                return -a.DeclarationOrder.CompareTo(b.DeclarationOrder);
-            });
+            affixes.Sort(
+                static (a, b) =>
+                {
+                    // Sort by descending declaration order
+                    // Lower declaration order means the affix is closer to the inside of the name
+                    return -a.DeclarationOrder.CompareTo(b.DeclarationOrder);
+                }
+            );
 
             var prefixes = affixes.Where(x => x.IsPrefix).ToList();
             var suffixes = affixes.Where(x => !x.IsPrefix).ToList();
@@ -1228,9 +1362,15 @@ public class PrettifyNames(
                     for (var i = 0; i < nameAffixes.Count; i++)
                     {
                         var affix = nameAffixes[i];
-                        if (isPrefix ? primary.StartsWith(affix.Affix) : primary.EndsWith(affix.Affix))
+                        if (
+                            isPrefix
+                                ? primary.StartsWith(affix.Affix)
+                                : primary.EndsWith(affix.Affix)
+                        )
                         {
-                            primary = isPrefix ? primary[affix.Affix.Length..] : primary[..^affix.Affix.Length];
+                            primary = isPrefix
+                                ? primary[affix.Affix.Length..]
+                                : primary[..^affix.Affix.Length];
 
                             nameAffixes.RemoveAt(i);
                             removedAffix = true;
@@ -1257,7 +1397,12 @@ public class PrettifyNames(
         /// <param name="originalName">The original name of the identifier. Either the type name or the member name.</param>
         /// <param name="secondary">The list of secondary names. This should be null if used by <see cref="ApplyPrettifyOnlyPipeline"/>.</param>
         /// <returns>The new primary name.</returns>
-        public string ApplyAffixes(string primary, string? container, string originalName, List<string>? secondary)
+        public string ApplyAffixes(
+            string primary,
+            string? container,
+            string originalName,
+            List<string>? secondary
+        )
         {
             var affixes = GetAffixes(container, originalName);
             if (affixes.Length == 0)
@@ -1272,17 +1417,21 @@ public class PrettifyNames(
             // Processing [..A] will give us our primary name
             // Processing [..A, ..B] will give us the first secondary name
             // Processing [..A, ..B, ..C] will give us the second secondary name
-            affixes.Sort((a, b) =>
-            {
-                // Sort so that non-discriminator affixes are first
-                if (GetConfiguration(a).IsDiscriminator != GetConfiguration(b).IsDiscriminator)
+            affixes.Sort(
+                (a, b) =>
                 {
-                    return GetConfiguration(a).IsDiscriminator.CompareTo(GetConfiguration(b).IsDiscriminator);
-                }
+                    // Sort so that non-discriminator affixes are first
+                    if (GetConfiguration(a).IsDiscriminator != GetConfiguration(b).IsDiscriminator)
+                    {
+                        return GetConfiguration(a)
+                            .IsDiscriminator.CompareTo(GetConfiguration(b).IsDiscriminator);
+                    }
 
-                // Then sort the remaining by descending priority
-                return -GetConfiguration(a).DiscriminatorPriority.CompareTo(GetConfiguration(b).DiscriminatorPriority);
-            });
+                    // Then sort the remaining by descending priority
+                    return -GetConfiguration(a)
+                        .DiscriminatorPriority.CompareTo(GetConfiguration(b).DiscriminatorPriority);
+                }
+            );
 
             // This is guaranteed to be non-null when this method returns if there is at least one affix
             string? newPrimary = null;
@@ -1299,7 +1448,10 @@ public class PrettifyNames(
                 }
 
                 // Process group if we reached the end of the non-discriminator affixes or if the priority changes
-                if (!hasProcessedNonDiscriminator || GetConfiguration(affix).DiscriminatorPriority < currentPriority)
+                if (
+                    !hasProcessedNonDiscriminator
+                    || GetConfiguration(affix).DiscriminatorPriority < currentPriority
+                )
                 {
                     hasProcessedNonDiscriminator = true;
                     currentPriority = GetConfiguration(affix).DiscriminatorPriority;
@@ -1319,19 +1471,21 @@ public class PrettifyNames(
             void CreateName(string name, Span<NameAffix> currentAffixes)
             {
                 // Sort affixes so that the inner affixes are first
-                currentAffixes.Sort((a, b) =>
-                {
-                    // Sort by descending order
-                    // Higher order means the affix is closer to the inside of the name
-                    if (GetConfiguration(a).Order != GetConfiguration(b).Order)
+                currentAffixes.Sort(
+                    (a, b) =>
                     {
-                        return -GetConfiguration(a).Order.CompareTo(GetConfiguration(b).Order);
-                    }
+                        // Sort by descending order
+                        // Higher order means the affix is closer to the inside of the name
+                        if (GetConfiguration(a).Order != GetConfiguration(b).Order)
+                        {
+                            return -GetConfiguration(a).Order.CompareTo(GetConfiguration(b).Order);
+                        }
 
-                    // Then by ascending declaration order
-                    // Lower declaration order means the affix is closer to the inside of the name
-                    return a.DeclarationOrder.CompareTo(b.DeclarationOrder);
-                });
+                        // Then by ascending declaration order
+                        // Lower declaration order means the affix is closer to the inside of the name
+                        return a.DeclarationOrder.CompareTo(b.DeclarationOrder);
+                    }
+                );
 
                 foreach (var affix in currentAffixes)
                 {
@@ -1380,7 +1534,9 @@ public class PrettifyNames(
 
             if (affixTypes.TryGetValue(container, out typeAffixData))
             {
-                if (typeAffixData.MemberAffixes?.TryGetValue(originalName, out var affixes) ?? false)
+                if (
+                    typeAffixData.MemberAffixes?.TryGetValue(originalName, out var affixes) ?? false
+                )
                 {
                     return affixes;
                 }
@@ -1389,9 +1545,11 @@ public class PrettifyNames(
             return [];
         }
 
-        private NameAffixConfiguration GetConfiguration(NameAffix affix) => GetConfiguration(affix.Category);
+        private NameAffixConfiguration GetConfiguration(NameAffix affix) =>
+            GetConfiguration(affix.Category);
 
-        private NameAffixConfiguration GetConfiguration(string category) => config.GetValueOrDefault(category, _defaultConfig);
+        private NameAffixConfiguration GetConfiguration(string category) =>
+            config.GetValueOrDefault(category, _defaultConfig);
     }
 
     /// <summary>
@@ -1423,7 +1581,12 @@ public class PrettifyNames(
             foreach (var (original, (primary, secondary)) in context.Names)
             {
                 var secondaries = secondary;
-                var newPrimary = affixer.RemoveAffixes(primary, context.Container, original, secondaries);
+                var newPrimary = affixer.RemoveAffixes(
+                    primary,
+                    context.Container,
+                    original,
+                    secondaries
+                );
                 context.Names[original] = new CandidateNames(newPrimary, secondaries);
             }
         }
@@ -1457,7 +1620,12 @@ public class PrettifyNames(
             foreach (var (original, (primary, secondary)) in context.Names)
             {
                 var secondaries = secondary;
-                var newPrimary = affixer.ApplyAffixes(primary, context.Container, original, secondaries);
+                var newPrimary = affixer.ApplyAffixes(
+                    primary,
+                    context.Container,
+                    original,
+                    secondaries
+                );
                 context.Names[original] = new CandidateNames(newPrimary, secondaries);
             }
         }
@@ -1483,7 +1651,10 @@ public class PrettifyNames(
                     secondary[i] = secondary[i].Prettify(nameTransformer, allowAllCaps);
                 }
 
-                context.Names[original] = new CandidateNames(primary.Prettify(nameTransformer, allowAllCaps), secondary);
+                context.Names[original] = new CandidateNames(
+                    primary.Prettify(nameTransformer, allowAllCaps),
+                    secondary
+                );
             }
         }
     }

--- a/sources/SilkTouch/SilkTouch/Mods/StripAttributes.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/StripAttributes.cs
@@ -45,10 +45,11 @@ public class StripAttributes(IOptionsSnapshot<StripAttributes.Configuration> cfg
         var rewriter = new Rewriter(config);
         foreach (var docId in proj.DocumentIds)
         {
-            var doc = proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
+            var doc =
+                proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
                 rewriter.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
-                ?? throw new InvalidOperationException("Visit returned null.")
+                    ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }
 
@@ -57,13 +58,20 @@ public class StripAttributes(IOptionsSnapshot<StripAttributes.Configuration> cfg
 
     private class Rewriter(Configuration config) : ModCSharpSyntaxRewriter
     {
-        private SyntaxList<AttributeListSyntax> StripAttributes(SyntaxList<AttributeListSyntax> attributeLists)
+        private SyntaxList<AttributeListSyntax> StripAttributes(
+            SyntaxList<AttributeListSyntax> attributeLists
+        )
         {
             var results = attributeLists
                 .Select(list =>
                 {
                     var attributes = list.Attributes;
-                    attributes = [..attributes.Where(attribute => !config.Remove.Contains(attribute.Name.ToString()))];
+                    attributes =
+                    [
+                        .. attributes.Where(attribute =>
+                            !config.Remove.Contains(attribute.Name.ToString())
+                        ),
+                    ];
 
                     return attributes.Count == 0 ? null : list.WithAttributes(attributes);
                 })

--- a/sources/SilkTouch/SilkTouch/Mods/TransformEnums.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/TransformEnums.cs
@@ -382,9 +382,9 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
                     if (baseTypes.Count == 0)
                     {
                         node = node.WithBaseList(
-                            BaseList([
-                                SimpleBaseType(PredefinedType(Token(SyntaxKind.UIntKeyword))),
-                            ])
+                            BaseList(
+                                [SimpleBaseType(PredefinedType(Token(SyntaxKind.UIntKeyword)))]
+                            )
                         );
                     }
                     else

--- a/sources/SilkTouch/SilkTouch/Mods/TransformEnums.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/TransformEnums.cs
@@ -65,7 +65,8 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
         /// The strategy to use when coercing backing types.
         /// Defaults to not modify the backing types at all.
         /// </summary>
-        public EnumBackingTypePreference CoerceBackingTypes { get; init; } = EnumBackingTypePreference.None;
+        public EnumBackingTypePreference CoerceBackingTypes { get; init; } =
+            EnumBackingTypePreference.None;
 
         /// <summary>
         /// Whether to rewrite enum member values or not.
@@ -116,7 +117,10 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
             {
                 if (configuration.MemberValue.StartsWith("0x"))
                 {
-                    MemberValue = long.Parse(configuration.MemberValue["0x".Length..], NumberStyles.AllowHexSpecifier);
+                    MemberValue = long.Parse(
+                        configuration.MemberValue["0x".Length..],
+                        NumberStyles.AllowHexSpecifier
+                    );
                 }
                 else
                 {
@@ -163,7 +167,9 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
     public async Task ExecuteAsync(IModContext ctx, CancellationToken ct = default)
     {
         var config = cfg.Get(ctx.JobKey);
-        var removeMemberFilters = config.RemoveMembers.Select(c => new EnumMemberFilter(c)).ToList();
+        var removeMemberFilters = config
+            .RemoveMembers.Select(c => new EnumMemberFilter(c))
+            .ToList();
 
         var proj = ctx.SourceProject;
         if (proj == null)
@@ -181,17 +187,23 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
         var rewriter = new Rewriter(config, removeMemberFilters, compilation, memberRewriteDecider);
         foreach (var docId in proj.DocumentIds)
         {
-            var doc = proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
+            var doc =
+                proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
                 rewriter.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
-                ?? throw new InvalidOperationException("Visit returned null.")
+                    ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }
 
         ctx.SourceProject = proj;
     }
 
-    private class Rewriter(Configuration config, List<EnumMemberFilter> removeMemberFilters, Compilation compilation, MemberRewriteDecider memberRewriteDecider) : CSharpSyntaxRewriter
+    private class Rewriter(
+        Configuration config,
+        List<EnumMemberFilter> removeMemberFilters,
+        Compilation compilation,
+        MemberRewriteDecider memberRewriteDecider
+    ) : CSharpSyntaxRewriter
     {
         public override SyntaxNode? VisitEnumDeclaration(EnumDeclarationSyntax node)
         {
@@ -223,31 +235,34 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
             if (isFlagsEnum && config.AddNoneMemberToFlags)
             {
                 // Add None member if it doesn't exist yet
-                var hasNoneMember = symbol.Members().Any(member =>
-                {
-                    if (member is not IFieldSymbol fieldSymbol)
+                var hasNoneMember = symbol
+                    .Members()
+                    .Any(member =>
                     {
-                        return false;
-                    }
+                        if (member is not IFieldSymbol fieldSymbol)
+                        {
+                            return false;
+                        }
 
-                    if (member.Name == "None")
-                    {
-                        return true;
-                    }
+                        if (member.Name == "None")
+                        {
+                            return true;
+                        }
 
-                    if (fieldSymbol.ConstantValue == null)
-                    {
-                        // We don't know the constant value for sure
-                        // Return false as a default
-                        return false;
-                    }
+                        if (fieldSymbol.ConstantValue == null)
+                        {
+                            // We don't know the constant value for sure
+                            // Return false as a default
+                            return false;
+                        }
 
-                    return Convert.ToInt64(fieldSymbol.ConstantValue) == 0;
-                });
+                        return Convert.ToInt64(fieldSymbol.ConstantValue) == 0;
+                    });
 
                 if (!hasNoneMember)
                 {
-                    var noneMember = EnumMemberDeclaration("None").WithEqualsValue(CreateEqualsValueClause(0, isFlagsEnum));
+                    var noneMember = EnumMemberDeclaration("None")
+                        .WithEqualsValue(CreateEqualsValueClause(0, isFlagsEnum));
                     members.Insert(0, noneMember);
                 }
             }
@@ -263,14 +278,26 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
                         {
                             var type = semanticModel.GetTypeInfo(t.Type).Type;
 
-                            if (SymbolEqualityComparer.Default.Equals(type, compilation.GetSpecialType(SpecialType.System_UInt32)))
+                            if (
+                                SymbolEqualityComparer.Default.Equals(
+                                    type,
+                                    compilation.GetSpecialType(SpecialType.System_UInt32)
+                                )
+                            )
                             {
                                 return null;
                             }
 
-                            if (SymbolEqualityComparer.Default.Equals(type, compilation.GetSpecialType(SpecialType.System_UInt64)))
+                            if (
+                                SymbolEqualityComparer.Default.Equals(
+                                    type,
+                                    compilation.GetSpecialType(SpecialType.System_UInt64)
+                                )
+                            )
                             {
-                                return SimpleBaseType(PredefinedType(Token(SyntaxKind.LongKeyword)));
+                                return SimpleBaseType(
+                                    PredefinedType(Token(SyntaxKind.LongKeyword))
+                                );
                             }
 
                             return t;
@@ -285,7 +312,7 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
                     }
                     else
                     {
-                        node = node.WithBaseList(BaseList([..baseTypes]));
+                        node = node.WithBaseList(BaseList([.. baseTypes]));
                     }
 
                     break;
@@ -293,7 +320,8 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
 
                 case EnumBackingTypePreference.PreferUnsigned:
                 {
-                    var hasNegativeValues = members.Any(m => {
+                    var hasNegativeValues = members.Any(m =>
+                    {
                         if (m.Parent == null)
                         {
                             return false;
@@ -321,14 +349,28 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
                         {
                             var type = semanticModel.GetTypeInfo(t.Type).Type;
 
-                            if (SymbolEqualityComparer.Default.Equals(type, compilation.GetSpecialType(SpecialType.System_Int32)))
+                            if (
+                                SymbolEqualityComparer.Default.Equals(
+                                    type,
+                                    compilation.GetSpecialType(SpecialType.System_Int32)
+                                )
+                            )
                             {
-                                return SimpleBaseType(PredefinedType(Token(SyntaxKind.UIntKeyword)));
+                                return SimpleBaseType(
+                                    PredefinedType(Token(SyntaxKind.UIntKeyword))
+                                );
                             }
 
-                            if (SymbolEqualityComparer.Default.Equals(type, compilation.GetSpecialType(SpecialType.System_Int64)))
+                            if (
+                                SymbolEqualityComparer.Default.Equals(
+                                    type,
+                                    compilation.GetSpecialType(SpecialType.System_Int64)
+                                )
+                            )
                             {
-                                return SimpleBaseType(PredefinedType(Token(SyntaxKind.ULongKeyword)));
+                                return SimpleBaseType(
+                                    PredefinedType(Token(SyntaxKind.ULongKeyword))
+                                );
                             }
 
                             return t;
@@ -339,11 +381,15 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
 
                     if (baseTypes.Count == 0)
                     {
-                        node = node.WithBaseList(BaseList([SimpleBaseType(PredefinedType(Token(SyntaxKind.UIntKeyword)))]));
+                        node = node.WithBaseList(
+                            BaseList([
+                                SimpleBaseType(PredefinedType(Token(SyntaxKind.UIntKeyword))),
+                            ])
+                        );
                     }
                     else
                     {
-                        node = node.WithBaseList(BaseList([..baseTypes]));
+                        node = node.WithBaseList(BaseList([.. baseTypes]));
                     }
 
                     break;
@@ -386,7 +432,7 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
                     .ToList();
             }
 
-            node = node.WithMembers([..members]);
+            node = node.WithMembers([.. members]);
 
             return base.VisitEnumDeclaration(node);
         }
@@ -395,8 +441,11 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
         {
             var stringValue = useHex ? $"0x{value:X}" : $"{value}";
             return EqualsValueClause(
-                LiteralExpression(SyntaxKind.NumericLiteralExpression,
-                    Literal([], stringValue, value, [])));
+                LiteralExpression(
+                    SyntaxKind.NumericLiteralExpression,
+                    Literal([], stringValue, value, [])
+                )
+            );
         }
     }
 

--- a/sources/SilkTouch/SilkTouch/Mods/TransformHandles.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/TransformHandles.cs
@@ -175,12 +175,10 @@ public class TransformHandles(
         CancellationToken ct
     ) : SymbolVisitor
     {
-        private readonly HashSet<IErrorTypeSymbol> _nonHandleTypes = new(
-            SymbolEqualityComparer.Default
-        );
-        private readonly Dictionary<IErrorTypeSymbol, string> _missingTypes = new(
-            SymbolEqualityComparer.Default
-        );
+        private readonly HashSet<IErrorTypeSymbol> _nonHandleTypes =
+            new(SymbolEqualityComparer.Default);
+        private readonly Dictionary<IErrorTypeSymbol, string> _missingTypes =
+            new(SymbolEqualityComparer.Default);
 
         private string? _currentNamespace = null;
         private int _pointerTypeDepth = 0;
@@ -743,10 +741,12 @@ public class TransformHandles(
                 )
                 .WithParameterList(
                     ParameterList(
-                        SeparatedList([
-                            Parameter(Identifier("left")).WithType(IdentifierName(structName)),
-                            Parameter(Identifier("right")).WithType(IdentifierName(structName)),
-                        ])
+                        SeparatedList(
+                            [
+                                Parameter(Identifier("left")).WithType(IdentifierName(structName)),
+                                Parameter(Identifier("right")).WithType(IdentifierName(structName)),
+                            ]
+                        )
                     )
                 )
                 .WithExpressionBody(
@@ -841,10 +841,12 @@ public class TransformHandles(
                 )
                 .WithParameterList(
                     ParameterList(
-                        SeparatedList([
-                            Parameter(Identifier("left")).WithType(IdentifierName(structName)),
-                            Parameter(Identifier("right")).WithType(IdentifierName("NullPtr")),
-                        ])
+                        SeparatedList(
+                            [
+                                Parameter(Identifier("left")).WithType(IdentifierName(structName)),
+                                Parameter(Identifier("right")).WithType(IdentifierName("NullPtr")),
+                            ]
+                        )
                     )
                 )
                 .WithExpressionBody(

--- a/sources/SilkTouch/SilkTouch/Mods/TransformHandles.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/TransformHandles.cs
@@ -31,7 +31,10 @@ namespace Silk.NET.SilkTouch.Mods;
 /// <c>Program</c>, <c>Program</c> must be declared in <c>Silk.NET.OpenGL</c>, <c>Silk.NET</c>, or <c>Silk</c>.
 /// </remarks>
 [ModConfiguration<Config>]
-public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, ILogger<TransformHandles> logger) : Mod
+public class TransformHandles(
+    IOptionsSnapshot<TransformHandles.Config> config,
+    ILogger<TransformHandles> logger
+) : Mod
 {
     /// <summary>
     /// The configuration for the <see cref="TransformHandles"/> mod.
@@ -82,10 +85,13 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
             foreach (var (fullyQualifiedName, node) in syntaxNodes)
             {
                 var relativePath = $"Handles/{PathForFullyQualified(fullyQualifiedName)}";
-                project = project.AddDocument(
-                    Path.GetFileName(relativePath),
-                    node.NormalizeWhitespace(),
-                    filePath: project.FullPath(relativePath)).Project;
+                project = project
+                    .AddDocument(
+                        Path.GetFileName(relativePath),
+                        node.NormalizeWhitespace(),
+                        filePath: project.FullPath(relativePath)
+                    )
+                    .Project;
             }
 
             // Update compilation
@@ -109,7 +115,9 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
             {
                 // The struct is defined in multiple places (eg: partial keyword)
                 // This means we don't know which of the parts to rewrite
-                throw new InvalidOperationException("Struct has more than 1 declaring syntax reference");
+                throw new InvalidOperationException(
+                    "Struct has more than 1 declaring syntax reference"
+                );
             }
 
             var declaringSyntaxReference = handleTypeSymbol.DeclaringSyntaxReferences.Single();
@@ -123,16 +131,22 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
         // Do the two following transformation to all references of the handle types:
         // 2. Reduce pointer dimensions
         ctx.SourceProject = project;
-        await LocationTransformationUtils.ModifyAllReferencesAsync(ctx, handleTypes, [
-            new PointerDimensionReductionTransformer(),
-        ], logger, ct);
+        await LocationTransformationUtils.ModifyAllReferencesAsync(
+            ctx,
+            handleTypes,
+            [new PointerDimensionReductionTransformer()],
+            logger,
+            ct
+        );
         project = ctx.SourceProject;
 
         // Use document IDs from earlier
         var handleTypeRewriter = new HandleTypeRewriter(cfg.UseDSL);
         foreach (var (originalName, documentId) in handleTypeDocumentIds)
         {
-            var document = project.GetDocument(documentId) ?? throw new InvalidOperationException("Failed to find document");
+            var document =
+                project.GetDocument(documentId)
+                ?? throw new InvalidOperationException("Failed to find document");
 
             var syntaxTree = await document.GetSyntaxTreeAsync(ct);
             if (syntaxTree == null)
@@ -143,7 +157,9 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
             var syntaxRoot = await syntaxTree.GetRootAsync(ct);
 
             // Rewrite handle struct to include handle members
-            document = document.WithSyntaxRoot(handleTypeRewriter.Visit(syntaxRoot).NormalizeWhitespace());
+            document = document.WithSyntaxRoot(
+                handleTypeRewriter.Visit(syntaxRoot).NormalizeWhitespace()
+            );
 
             project = document.Project;
         }
@@ -153,10 +169,18 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
         return;
     }
 
-    private class MissingHandleTypeDiscoverer(ILogger logger, Compilation compilation, CancellationToken ct) : SymbolVisitor
+    private class MissingHandleTypeDiscoverer(
+        ILogger logger,
+        Compilation compilation,
+        CancellationToken ct
+    ) : SymbolVisitor
     {
-        private readonly HashSet<IErrorTypeSymbol> _nonHandleTypes = new(SymbolEqualityComparer.Default);
-        private readonly Dictionary<IErrorTypeSymbol, string> _missingTypes = new(SymbolEqualityComparer.Default);
+        private readonly HashSet<IErrorTypeSymbol> _nonHandleTypes = new(
+            SymbolEqualityComparer.Default
+        );
+        private readonly Dictionary<IErrorTypeSymbol, string> _missingTypes = new(
+            SymbolEqualityComparer.Default
+        );
 
         private string? _currentNamespace = null;
         private int _pointerTypeDepth = 0;
@@ -169,7 +193,8 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
             // We need to find and generate all missing handle types
             // Handle types are types that are only referenced through a pointer
             // We do this by parsing through the list of type errors
-            var typeErrors = compilation.GetDiagnostics(ct)
+            var typeErrors = compilation
+                .GetDiagnostics(ct)
                 .Where(d => d.Id == "CS0246") // Type errors
                 .ToList();
 
@@ -215,7 +240,10 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                         }
                         case MemberDeclarationSyntax memberDeclarationSyntax:
                         {
-                            var symbol = semanticModel.GetDeclaredSymbol(memberDeclarationSyntax, ct);
+                            var symbol = semanticModel.GetDeclaredSymbol(
+                                memberDeclarationSyntax,
+                                ct
+                            );
                             if (symbol != null)
                             {
                                 symbolsFound.Add(symbol);
@@ -239,7 +267,9 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                 if (!isSuccess)
                 {
                     // This is to warn of unhandled cases
-                    logger.LogWarning("Failed to find corresponding symbol for type error. There may be an unhandled case in the code");
+                    logger.LogWarning(
+                        "Failed to find corresponding symbol for type error. There may be an unhandled case in the code"
+                    );
                 }
             }
 
@@ -249,7 +279,10 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                 Visit(symbol);
             }
 
-            return new Dictionary<IErrorTypeSymbol, string>(_missingTypes.Where(kvp => !_nonHandleTypes.Contains(kvp.Key)), SymbolEqualityComparer.Default);
+            return new Dictionary<IErrorTypeSymbol, string>(
+                _missingTypes.Where(kvp => !_nonHandleTypes.Contains(kvp.Key)),
+                SymbolEqualityComparer.Default
+            );
         }
 
         public override void VisitMethod(IMethodSymbol symbol)
@@ -317,7 +350,9 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
             {
                 if (_currentNamespace == null)
                 {
-                    throw new InvalidOperationException($"{nameof(_currentNamespace)} should not be null");
+                    throw new InvalidOperationException(
+                        $"{nameof(_currentNamespace)} should not be null"
+                    );
                 }
 
                 if (_pointerTypeDepth == 0)
@@ -327,7 +362,9 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
 
                 if (_missingTypes.TryGetValue(errorTypeSymbol, out var sharedNamespace))
                 {
-                    _missingTypes[errorTypeSymbol] = NameUtils.FindCommonPrefix([sharedNamespace, _currentNamespace], true, false, true).Trim('.');
+                    _missingTypes[errorTypeSymbol] = NameUtils
+                        .FindCommonPrefix([sharedNamespace, _currentNamespace], true, false, true)
+                        .Trim('.');
                 }
                 else
                 {
@@ -345,10 +382,13 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
         /// <param name="typesToGenerate">Map from error type symbol to the namespace the type should be created in.</param>
         /// <returns>Map from the fully qualified name of the generated type to the syntax node containing code for that type.</returns>
         public Dictionary<string, SyntaxNode> GenerateSyntaxNodes(
-            Dictionary<IErrorTypeSymbol, string> typesToGenerate) =>
-            GenerateSyntaxNodes(typesToGenerate
-                .Select(kvp => new KeyValuePair<string, string>(kvp.Key.Name, kvp.Value))
-                .ToDictionary());
+            Dictionary<IErrorTypeSymbol, string> typesToGenerate
+        ) =>
+            GenerateSyntaxNodes(
+                typesToGenerate
+                    .Select(kvp => new KeyValuePair<string, string>(kvp.Key.Name, kvp.Value))
+                    .ToDictionary()
+            );
 
         /// <summary>
         /// Generates a syntax node for each specified type.
@@ -356,7 +396,8 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
         /// <param name="missingHandleTypes">Map from type name to the namespace the type should be created in.</param>
         /// <returns>Map from the fully qualified name of the generated type to the syntax node containing code for that type.</returns>
         public Dictionary<string, SyntaxNode> GenerateSyntaxNodes(
-            Dictionary<string, string> missingHandleTypes)
+            Dictionary<string, string> missingHandleTypes
+        )
         {
             var results = new Dictionary<string, SyntaxNode>();
             foreach (var (name, ns) in missingHandleTypes)
@@ -379,7 +420,11 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                                 : FileScopedNamespaceDeclaration(
                                         ModUtils.NamespaceIntoIdentifierName(ns)
                                     )
-                                    .WithMembers(SingletonList<MemberDeclarationSyntax>(structDeclarationSyntax))
+                                    .WithMembers(
+                                        SingletonList<MemberDeclarationSyntax>(
+                                            structDeclarationSyntax
+                                        )
+                                    )
                         )
                     );
             }
@@ -388,7 +433,11 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
         }
     }
 
-    private class HandleTypeDiscoverer(Project project, Compilation compilation, CancellationToken ct) : SymbolVisitor
+    private class HandleTypeDiscoverer(
+        Project project,
+        Compilation compilation,
+        CancellationToken ct
+    ) : SymbolVisitor
     {
         private readonly Solution _solution = project.Solution;
 
@@ -412,7 +461,12 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                 // For each struct, find its references
                 // Verify that all references are through pointers
                 // Also verify that there is at least one reference through a pointer
-                var references = await SymbolFinder.FindReferencesAsync(structSymbol, _solution, documents, ct);
+                var references = await SymbolFinder.FindReferencesAsync(
+                    structSymbol,
+                    _solution,
+                    documents,
+                    ct
+                );
 
                 var wasReferencedAsPointer = false;
                 var wasReferencedAsNonPointer = false;
@@ -468,7 +522,11 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
             // Find empty structs
             // IsImplicitlyDeclared lets us ignore implicitly declared constructors
             // SpecialType lets us ignore Void and System.RuntimeArgumentHandle
-            if (symbol.TypeKind != TypeKind.Struct || symbol.Members().Any(member => !member.IsImplicitlyDeclared) || symbol.SpecialType != SpecialType.None)
+            if (
+                symbol.TypeKind != TypeKind.Struct
+                || symbol.Members().Any(member => !member.IsImplicitlyDeclared)
+                || symbol.SpecialType != SpecialType.None
+            )
             {
                 return;
             }
@@ -482,15 +540,16 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
         public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
         {
             var structName = node.Identifier.Text;
-            return node
-                .WithIdentifier(Identifier(structName))
+            return node.WithIdentifier(Identifier(structName))
                 .WithAttributeLists(
                     new SyntaxList<AttributeListSyntax>()
                         .WithNativeName(structName)
-                        .AddNameSuffix("HandleType", "Handle"))
+                        .AddNameSuffix("HandleType", "Handle")
+                )
                 .WithMembers(
                     List(
-                        GetDefaultHandleMembers(structName).Concat(useDSL ? GetDSLHandleMembers(structName) : [])
+                        GetDefaultHandleMembers(structName)
+                            .Concat(useDSL ? GetDSLHandleMembers(structName) : [])
                     )
                 )
                 .WithModifiers(
@@ -503,7 +562,9 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                 );
         }
 
-        private static IEnumerable<MemberDeclarationSyntax> GetDefaultHandleMembers(string structName)
+        private static IEnumerable<MemberDeclarationSyntax> GetDefaultHandleMembers(
+            string structName
+        )
         {
             var backingType = PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword)));
 
@@ -518,11 +579,13 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                 );
 
             yield return ConstructorDeclaration(Identifier(structName))
-                .WithModifiers(
-                    TokenList(Token(SyntaxKind.PublicKeyword))
-                )
-                .WithParameterList(ParameterList(
-                    SingletonSeparatedList(Parameter(Identifier("handle")).WithType(backingType)))
+                .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                .WithParameterList(
+                    ParameterList(
+                        SingletonSeparatedList(
+                            Parameter(Identifier("handle")).WithType(backingType)
+                        )
+                    )
                 )
                 .WithBody(
                     Block(
@@ -648,7 +711,7 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                             {
                                 Parameter(Identifier("left")).WithType(IdentifierName(structName)),
                                 Token(SyntaxKind.CommaToken),
-                                Parameter(Identifier("right")).WithType(IdentifierName(structName))
+                                Parameter(Identifier("right")).WithType(IdentifierName(structName)),
                             }
                         )
                     )
@@ -680,12 +743,10 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                 )
                 .WithParameterList(
                     ParameterList(
-                        SeparatedList(
-                            [
-                                Parameter(Identifier("left")).WithType(IdentifierName(structName)),
-                                Parameter(Identifier("right")).WithType(IdentifierName(structName))
-                            ]
-                        )
+                        SeparatedList([
+                            Parameter(Identifier("left")).WithType(IdentifierName(structName)),
+                            Parameter(Identifier("right")).WithType(IdentifierName(structName)),
+                        ])
                     )
                 )
                 .WithExpressionBody(
@@ -748,7 +809,7 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                             {
                                 Parameter(Identifier("left")).WithType(IdentifierName(structName)),
                                 Token(SyntaxKind.CommaToken),
-                                Parameter(Identifier("right")).WithType(IdentifierName("NullPtr"))
+                                Parameter(Identifier("right")).WithType(IdentifierName("NullPtr")),
                             }
                         )
                     )
@@ -780,12 +841,10 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                 )
                 .WithParameterList(
                     ParameterList(
-                        SeparatedList(
-                            [
-                                Parameter(Identifier("left")).WithType(IdentifierName(structName)),
-                                Parameter(Identifier("right")).WithType(IdentifierName("NullPtr"))
-                            ]
-                        )
+                        SeparatedList([
+                            Parameter(Identifier("left")).WithType(IdentifierName(structName)),
+                            Parameter(Identifier("right")).WithType(IdentifierName("NullPtr")),
+                        ])
                     )
                 )
                 .WithExpressionBody(

--- a/sources/SilkTouch/SilkTouch/Mods/Transformation/ArrayParameterTransformer.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Transformation/ArrayParameterTransformer.cs
@@ -87,8 +87,8 @@ public class ArrayParameterTransformer : IFunctionTransformer
                         x.CountParamIdx,
                         // 2. Select only the last parameter this count parameter is associated with
                         ParamForCount: x.ParamsForCount.Select(
-                            (y, j) => (PtrParamInfo: y, ParamForCountIdx: j)
-                        )
+                                (y, j) => (PtrParamInfo: y, ParamForCountIdx: j)
+                            )
                             .LastOrDefault()
                     )
                 )
@@ -234,7 +234,12 @@ public class ArrayParameterTransformer : IFunctionTransformer
         public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node) =>
             node.WithIdentifier(
                     // TODO: Temporarily hack to fix issue where OpenGL -OES vendor suffix gets replaced with -O
-                    Identifier(node.Identifier.Text.EndsWith("OES") ? node.Identifier.Text : node.Identifier.Text.Singularize(false)))
+                    Identifier(
+                        node.Identifier.Text.EndsWith("OES")
+                            ? node.Identifier.Text
+                            : node.Identifier.Text.Singularize(false)
+                    )
+                )
                 .WithReturnType(
                     isOutput ? ptrElementType : PredefinedType(Token(SyntaxKind.VoidKeyword))
                 )
@@ -255,7 +260,6 @@ public class ArrayParameterTransformer : IFunctionTransformer
                             // call.
                             ? Block(
                                 (StatementSyntax[])
-
                                     [
                                         LocalDeclarationStatement(
                                             VariableDeclaration(
@@ -273,7 +277,7 @@ public class ArrayParameterTransformer : IFunctionTransformer
                                             )
                                         ),
                                         .. blk.Statements,
-                                        ReturnStatement(IdentifierName(ptrParam))
+                                        ReturnStatement(IdentifierName(ptrParam)),
                                     ]
                             )
                             : blk
@@ -311,15 +315,15 @@ public class ArrayParameterTransformer : IFunctionTransformer
                 ? syn.WithParameters(
                     SeparatedList(
                         syn.Parameters.Select(x =>
-                            x.Identifier.ToString() == countParam
-                            || (isOutput && x.Identifier.ToString() == ptrParam)
-                                ? null
+                                x.Identifier.ToString() == countParam
+                                || (isOutput && x.Identifier.ToString() == ptrParam)
+                                    ? null
                                 : base.VisitParameter(x) is ParameterSyntax p
                                     ? p.Identifier.ToString() == ptrParam
-                                        ? p.WithType(ptrElementType)
+                                            ? p.WithType(ptrElementType)
                                         : p
-                                    : null
-                        )
+                                : null
+                            )
                             .OfType<ParameterSyntax>()
                     )
                 )

--- a/sources/SilkTouch/SilkTouch/Mods/Transformation/FunctionTransformer.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Transformation/FunctionTransformer.cs
@@ -182,7 +182,8 @@ public class FunctionTransformer(
                         .WithIdentifier(Identifier(newIden));
 
                     newFun = newFun.WithAttributeLists(
-                        newFun.AttributeLists.AddNameSuffix("RawFunction", "Raw"));
+                        newFun.AttributeLists.AddNameSuffix("RawFunction", "Raw")
+                    );
 
                     discrim = ModUtils.DiscrimStr(
                         function.Modifiers,
@@ -255,7 +256,9 @@ public class FunctionTransformer(
                                     x.Attributes.Where(y =>
                                         !y.IsAttribute("System.Runtime.InteropServices.DllImport")
                                         && !y.IsAttribute("Silk.NET.Core.NativeFunction")
-                                        && !y.IsAttribute("System.Runtime.CompilerServices.MethodImpl")
+                                        && !y.IsAttribute(
+                                            "System.Runtime.CompilerServices.MethodImpl"
+                                        )
                                     )
                                 )
                             )

--- a/sources/SilkTouch/SilkTouch/Naming/CandidateNamesWithOriginal.cs
+++ b/sources/SilkTouch/SilkTouch/Naming/CandidateNamesWithOriginal.cs
@@ -10,7 +10,11 @@ namespace Silk.NET.SilkTouch.Naming;
 /// <param name="Primary">The preferred version of the trimmed name.</param>
 /// <param name="Secondary">The fallback versions of the trimmed name in case the primary does not work.</param>
 /// <param name="Original">The original, unmodified name.</param>
-public record struct CandidateNamesWithOriginal(string Primary, List<string> Secondary, string Original)
+public record struct CandidateNamesWithOriginal(
+    string Primary,
+    List<string> Secondary,
+    string Original
+)
 {
     /// <summary>
     /// Formats this instance as a string.

--- a/sources/SilkTouch/SilkTouch/Naming/NameTrimmer.cs
+++ b/sources/SilkTouch/SilkTouch/Naming/NameTrimmer.cs
@@ -168,7 +168,10 @@ public class NameTrimmer : INameTrimmer
                 // this was trimmingName originally. given that we're using trimming name to determine a prefix but then
                 // using that prefix on the old primary, this could cause intended behaviour in some cases. there's probably
                 // a better way to do this. (this is working around glDisablei -> glDisable -> Disablei).
-                context.Names![originalName] = new CandidateNames(oldPrimary[prefixLen..].Trim('_'), sec);
+                context.Names![originalName] = new CandidateNames(
+                    oldPrimary[prefixLen..].Trim('_'),
+                    sec
+                );
                 break;
             }
         }

--- a/sources/SilkTouch/SilkTouch/Naming/NameUtils.cs
+++ b/sources/SilkTouch/SilkTouch/Naming/NameUtils.cs
@@ -46,7 +46,11 @@ public static partial class NameUtils
     /// </param>
     /// <param name="allowAllCaps">Whether the output is allowed to be fully capitalised ("all caps").</param>
     /// <returns>The pretty string.</returns>
-    public static string Prettify(this string str, ICulturedStringTransformer nameTransformer, bool allowAllCaps = false)
+    public static string Prettify(
+        this string str,
+        ICulturedStringTransformer nameTransformer,
+        bool allowAllCaps = false
+    )
     {
         if (str.Length == 0)
         {
@@ -64,7 +68,9 @@ public static partial class NameUtils
 
         if (ret.Length == 0)
         {
-            throw new InvalidOperationException($"Prettification for '{str}' led to an empty string");
+            throw new InvalidOperationException(
+                $"Prettification for '{str}' led to an empty string"
+            );
         }
 
         // Disallow all capitals
@@ -328,8 +334,12 @@ public static partial class NameUtils
     )
     {
         var newNames = toRename.ToList();
-        await LocationTransformationUtils.ModifyAllReferencesAsync(ctx, newNames.Select(x => x.Symbol), [
-            new IdentifierRenamingTransformer(newNames),
-        ], logger, ct);
+        await LocationTransformationUtils.ModifyAllReferencesAsync(
+            ctx,
+            newNames.Select(x => x.Symbol),
+            [new IdentifierRenamingTransformer(newNames)],
+            logger,
+            ct
+        );
     }
 }

--- a/sources/SilkTouch/SilkTouch/Sources/IInputResolver.cs
+++ b/sources/SilkTouch/SilkTouch/Sources/IInputResolver.cs
@@ -89,10 +89,13 @@ public interface IInputResolver
                     (await TryResolvePath(rsp.FileDirectory))?.Replace('\\', '/')
                     ?? rsp.FileDirectory,
                 ClangCommandLineArgs = rsp.ClangCommandLineArgs,
-                GeneratorConfiguration = rsp.GeneratorConfiguration.ToWrapper() with {
+                GeneratorConfiguration = rsp.GeneratorConfiguration.ToWrapper() with
+                {
                     OutputLocation = await ResolvePath(rsp.GeneratorConfiguration.OutputLocation),
                     TraversalNames = traversals,
-                    TestOutputLocation = await ResolvePath(rsp.GeneratorConfiguration.TestOutputLocation),
+                    TestOutputLocation = await ResolvePath(
+                        rsp.GeneratorConfiguration.TestOutputLocation
+                    ),
                 },
             };
         }
@@ -130,7 +133,7 @@ public interface IInputResolver
                 : await ResolvePath(config.InputSourceRoot),
             InputTestRoot = config.InputTestRoot is null
                 ? null
-                : await ResolvePath(config.InputTestRoot)
+                : await ResolvePath(config.InputTestRoot),
         };
     }
 
@@ -145,6 +148,6 @@ public interface IInputResolver
             SourceProject = config.SourceProject is null
                 ? null
                 : await ResolvePath(config.SourceProject),
-            TestProject = config.TestProject is null ? null : await ResolvePath(config.TestProject)
+            TestProject = config.TestProject is null ? null : await ResolvePath(config.TestProject),
         };
 }

--- a/tests/SilkTouch/SilkTouch/Khronos/MixKhronosDataTests.cs
+++ b/tests/SilkTouch/SilkTouch/Khronos/MixKhronosDataTests.cs
@@ -264,8 +264,7 @@ public class MixKhronosDataTests
                         .SupportedApiProfiles?.OrderBy(x => x.Key)
                         .Select(x =>
                             $"{x.Key}\n{new string('-', x.Key.Length)}\n{string.Join('\n', x.Value.Select(y => AttributeList(SingletonSeparatedList(y.GetSupportedApiProfileAttribute())).ToString()).Order())}\n"
-                        )
-                        ?? []
+                        ) ?? []
                 )
             )
             .UseFileName($"{nameof(MixKhronosDataTests)}.{nameof(SupportedApiProfiles)}.{file}");

--- a/tests/SilkTouch/SilkTouch/Khronos/MixKhronosDataTests.cs
+++ b/tests/SilkTouch/SilkTouch/Khronos/MixKhronosDataTests.cs
@@ -264,7 +264,8 @@ public class MixKhronosDataTests
                         .SupportedApiProfiles?.OrderBy(x => x.Key)
                         .Select(x =>
                             $"{x.Key}\n{new string('-', x.Key.Length)}\n{string.Join('\n', x.Value.Select(y => AttributeList(SingletonSeparatedList(y.GetSupportedApiProfileAttribute())).ToString()).Order())}\n"
-                        ) ?? []
+                        )
+                        ?? []
                 )
             )
             .UseFileName($"{nameof(MixKhronosDataTests)}.{nameof(SupportedApiProfiles)}.{file}");
@@ -339,7 +340,10 @@ public class MixKhronosDataTests
         var names = new Dictionary<string, CandidateNames>
         {
             { "GL_PIXEL_COUNT_NV", new CandidateNames("GL_PIXEL_COUNT_NV", []) },
-            { "GL_PIXEL_COUNT_AVAILABLE_NV", new CandidateNames("GL_PIXEL_COUNT_AVAILABLE_NV", []) },
+            {
+                "GL_PIXEL_COUNT_AVAILABLE_NV",
+                new CandidateNames("GL_PIXEL_COUNT_AVAILABLE_NV", [])
+            },
         };
         var ctx = new NameTrimmerContext
         {
@@ -351,7 +355,10 @@ public class MixKhronosDataTests
         baseTrimmer.Trim(ctx);
         uut.Trim(ctx);
         Assert.That(names["GL_PIXEL_COUNT_NV"].Primary, Is.EqualTo("PixelCount"));
-        Assert.That(names["GL_PIXEL_COUNT_AVAILABLE_NV"].Primary, Is.EqualTo("PixelCountAvailable"));
+        Assert.That(
+            names["GL_PIXEL_COUNT_AVAILABLE_NV"].Primary,
+            Is.EqualTo("PixelCountAvailable")
+        );
     }
 
     [Test]

--- a/tests/SilkTouch/SilkTouch/Naming/NameTests.cs
+++ b/tests/SilkTouch/SilkTouch/Naming/NameTests.cs
@@ -52,7 +52,10 @@ public class NameTests : NameTrimmer
         };
         foreach (var (key, (trimmed, _)) in test)
         {
-            Assert.That(trimmed.Prettify(new NameUtils.NameTransformer(4)), Is.EqualTo(expected[key]));
+            Assert.That(
+                trimmed.Prettify(new NameUtils.NameTransformer(4)),
+                Is.EqualTo(expected[key])
+            );
         }
     }
 
@@ -84,7 +87,10 @@ public class NameTests : NameTrimmer
         };
         foreach (var (key, (trimmed, _)) in test)
         {
-            Assert.That(trimmed.Prettify(new NameUtils.NameTransformer(4)), Is.EqualTo(expected[key]));
+            Assert.That(
+                trimmed.Prettify(new NameUtils.NameTransformer(4)),
+                Is.EqualTo(expected[key])
+            );
         }
     }
 
@@ -112,7 +118,10 @@ public class NameTests : NameTrimmer
         };
         foreach (var (key, (trimmed, _)) in test)
         {
-            Assert.That(trimmed.Prettify(new NameUtils.NameTransformer(4)), Is.EqualTo(expected[key]));
+            Assert.That(
+                trimmed.Prettify(new NameUtils.NameTransformer(4)),
+                Is.EqualTo(expected[key])
+            );
         }
     }
 
@@ -158,6 +167,9 @@ public class NameTests : NameTrimmer
         };
         var uut = new NameTrimmer();
         uut.Trim(ctx);
-        Assert.That(names["ALC_CONTEXT_DEBUG_BIT_EXT"].Primary, Is.EqualTo("CONTEXT_DEBUG_BIT_EXT"));
+        Assert.That(
+            names["ALC_CONTEXT_DEBUG_BIT_EXT"].Primary,
+            Is.EqualTo("CONTEXT_DEBUG_BIT_EXT")
+        );
     }
 }


### PR DESCRIPTION
# Summary of the PR
This reorders the affixes so that the KhronosVendor suffixes are last.
Eg: `AcquireKeyedMutexWin32EXTRaw` becomes `AcquireKeyedMutexWin32RawEXT`

# Related issues, Discord discussions, or proposals
Request by Perksey in Discord: https://discord.com/channels/521092042781229087/587346162802229298/1457860423771488499

# Further Comments
N/A